### PR TITLE
Imp travis run tests

### DIFF
--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -30,33 +30,6 @@ do
     addons_path=${repo},${addons_path}
 done
 
-
-echo "working in $TRAVIS_BUILD_DIR"
-ls ${TRAVIS_BUILD_DIR}
-for name in $(ls ${TRAVIS_BUILD_DIR});
-do
-    echo "considering $name"
-    stripped_name=$(echo ${name} | sed 's/_unported$//')
-    if check_installable ${TRAVIS_BUILD_DIR}/${name}
-    then
-        if [ -v tested_addons ]
-        then
-            tested_addons=${name},${tested_addons}
-        else
-            tested_addons=$name
-        fi
-    else
-        echo " -> probably not an addon"
-    fi
-done
-
-if [ ! -v tested_addons ]
-then
-    echo "no addon to test"
-    # should we error?
-    exit 0
-fi
-
 psql -c 'create database ${module_name} with owner openerp;' -U postgres
 # setup the base module without running the tests
 echo


### PR DESCRIPTION
This should allow the .travis.yml file to just run the single test on different DBs calling travis_run_tests for every module
Something like

```
travis_run_tests 7.0 account_invoice_production_lot $HOME/reporting-engine $HOME/stock-logistics-workflow $HOME/webkit-tools
travis_run_tests 7.0 picking_dispatch_wave $HOME/reporting-engine $HOME/stock-logistics-workflow $HOME/webkit-tools
```

Also see https://github.com/OCA/account-invoice-reporting/pull/4#issuecomment-48040090
