### PR TITLE
travis_run_flake8 return condition should use...

### DIFF
--- a/travis/travis_run_flake8
+++ b/travis/travis_run_flake8
@@ -6,4 +6,4 @@ flake8 . --max-line-length=${LINE_LENGTH} --filename=__init__.py --ignore=F401 -
 status1=$?
 flake8 . --max-line-length=${LINE_LENGTH} --exclude=__unported__,__init__.py
 status2=$?
-exit $((${status1} && ${status2}))
+exit $((${status1} || ${status2}))


### PR DESCRIPTION
... an OR between the 2 commands because if one of them fail, we don't want to have 0 returned.

The side effect of this bug is that as soon as one of the command successes, the travis build is considered successful (at least for the flake8 part).
