### PR TITLE
Init addons and their dependencies before tests

### DIFF
--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -62,7 +62,7 @@ psql -c "create database ${database} with owner openerp;" -U postgres
 # setup the base module without running the tests
 echo
 echo setting up the database
-/usr/bin/openerp-server --db_user=openerp --db_password=admin -d ${database} --addons-path=${addons_path} ${install_options} --stop-after-init -i base
+/usr/bin/openerp-server --db_user=openerp --db_password=admin -d ${database} --addons-path=${addons_path} ${install_options} --stop-after-init -i ${tested_addons}
 
 command="/usr/bin/openerp-server --db_user=openerp --db_password=admin -d ${database} ${options} \
 --stop-after-init  --log-level test \


### PR DESCRIPTION
Speed up testing
Skip tests of modules outside repo

Travis should not be running unittests other than the ones in the repo
Odoo will test every module it initializes, this is why the `setting up the database` should also install the `tested_addons`, thereby installing the dependencies without having to run their tests each time.
