### PR TITLE
6.1 Catch error

### DIFF
--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -73,7 +73,7 @@ echo
 echo ${command}
 coverage run $command | tee stdout.log
 
-if $(grep -v mail stdout.log | grep -q "At least one test failed when loading the modules.")
+if $(grep -v mail stdout.log | egrep -q "(At least one test failed when loading the modules.|ERROR ${database})")
 then
     exit 1
 else


### PR DESCRIPTION
In 6.1, the unittests will not give the message "At least one test failed when loading the modules."
Look for "ERROR openerp_test", which will apear in both 6.1 and 7.0.

[Example case with false positive](https://travis-ci.org/OCA/product-attribute/builds/29492172)
