### PR TITLE
Fix check errors for v7 (fixes #60)

### DIFF
--- a/tests/test_repo/broken_module/__init__.py
+++ b/tests/test_repo/broken_module/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+# none

--- a/tests/test_repo/broken_module/__openerp__.py
+++ b/tests/test_repo/broken_module/__openerp__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Broken module for tests',
+    'version': '1.0',
+    'depends': ['base'],
+    'data': ['broken_view.xml'],
+    'installable': False,  # wait for the self test machinery
+}

--- a/tests/test_repo/broken_module/broken_view.xml
+++ b/tests/test_repo/broken_module/broken_view.xml
@@ -1,0 +1,3 @@
+<data>
+    <broke>This will error!</broken>
+</data>

--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -10,16 +10,26 @@ from getaddons import get_addons
 from getaddons import get_modules
 
 
-def has_test_errors(stdout, database):
+def has_test_errors(fname, database):
     """
     Check a list of log lines for test errors.
     Extension point to detect false positives.
     """
+    print("--------")
+    # Read log file removing ASCII color escapes:
+    # http://serverfault.com/questions/71285
+    cmd = 'sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" %s' % fname
+    stdout = subprocess.check_output(cmd, shell=True).split('\n')
     errors = [
         x for x in stdout
         if "mail" not in x
         and ("ERROR %s" % database in x
+             or "CRITICAL %s" % database in x
              or "At least one test failed" in x)]
+    if errors:
+        print("--------")
+        for e in errors:
+            print(e)
     return len(errors)
 
 
@@ -84,11 +94,12 @@ def main():
     command_call = "unbuffer %s | tee stdout.log" % command
     subprocess.check_call(command_call, shell=True)
     # Find errors, except from failed mails
-    stdout = open("stdout.log").readlines()
-    if has_test_errors(stdout, database):
-        return(1)
+    errors = has_test_errors("stdout.log", database)
+    if errors:
+        print("Found %d lines with errors" % errors)
+        return 1
     # if we get here, all is OK
-    return(0)
+    return 0
 
 if __name__ == '__main__':
     exit(main())


### PR DESCRIPTION
The problem were the ANSI color escape code.
Added corresponding cleanup, and the errors are now detected.
I checked it with this on time test: https://travis-ci.org/dreispt/maintainer-quality-tools/jobs/31859994
