### PR TITLE
Flake8 expects the number of chars, not the nominal length

### DIFF
--- a/travis/cfg/travis_run_flake8.cfg
+++ b/travis/cfg/travis_run_flake8.cfg
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 80
+max-line-length = 79
 exclude = __unported__,__init__.py

--- a/travis/cfg/travis_run_flake8__init__.cfg
+++ b/travis/cfg/travis_run_flake8__init__.cfg
@@ -1,6 +1,6 @@
 [flake8]
 ignore = F401
-max-line-length = 80
+max-line-length = 79
 exclude = __unported__
 filename = __init__.py
 


### PR DESCRIPTION
The nominal length is 79 chars + \n. The max line length is 79.

Fixes #77
