### PR TITLE
[IMP] allow more fine-grained control over what counts as error

### DIFF
--- a/travis/test_server
+++ b/travis/test_server
@@ -43,7 +43,7 @@ def has_test_errors(fname, dbname, odoo_version):
             if isinstance(pattern_list[i], basestring):
                 regex = re.compile(pattern_list[i])
                 pattern_list[i] = lambda x: regex.match(x['message'])
-            elif isinstance(pattern_list[i], re.RegexObject):
+            elif hasattr(pattern_list[i], 'match'):
                 regex = pattern_list[i]
                 pattern_list[i] = lambda x: regex.match(x['message'])
 


### PR DESCRIPTION
This allows us to cover situations where a message indicates a problem, but not always. For an example, see the discussion in https://github.com/OCA/server-tools/pull/65
