### PR TITLE
Ignore F811 (redefinition of unused '')

### DIFF
--- a/travis/cfg/travis_run_flake8.cfg
+++ b/travis/cfg/travis_run_flake8.cfg
@@ -1,3 +1,4 @@
 [flake8]
+ignore = F811
 max-line-length = 79
 exclude = __unported__,__init__.py


### PR DESCRIPTION
Because it is valid code in the new API (odoo v8) when we implement
2 interfaces for a method (compatible with old and new API).

Closes #106
