### PR TITLE
[IMP][pylint-conf] Add deprecated modules: pdb, pudb. And enable fails W0402 to check it #112

### DIFF
--- a/travis/cfg/travis_run_pylint.cfg
+++ b/travis/cfg/travis_run_pylint.cfg
@@ -6,7 +6,7 @@ cache-size=500
 
 [MESSAGES CONTROL]
 disable=all
-enable=E0101,E1124,E1306,E1601,I0013,W0101,W0102,W0104,W0105,W0109,W0403,W0404,W1111,W1401
+enable=E0101,E1124,E1306,E1601,I0013,W0101,W0102,W0104,W0105,W0109,W0403,W0404,W1111,W1401,W0402
 
 [REPORTS]
 msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
@@ -25,3 +25,7 @@ ignore-docstrings=yes
 
 [MISCELLANEOUS]
 notes=
+
+[IMPORTS]
+deprecated-modules=pdb,pudb,ipdb
+


### PR DESCRIPTION
More info here:
https://github.com/OCA/maintainer-quality-tools/issues/112

We need enable 
W0402(deprecated-module) to detect conf
+[IMPORTS]
+deprecated-modules=pdb,pudb
But show fail only if module is installed.

And we need enable 
F0401(import-error)
If you try use deprecated modules without install depends.

And now "import openerp" show a import-error then I add odoo directory to PYTHONPATH to detect this import. 