### PR TITLE
fix #115: restore default pep8 ignore

### DIFF
--- a/travis/cfg/travis_run_flake8.cfg
+++ b/travis/cfg/travis_run_flake8.cfg
@@ -1,4 +1,6 @@
 [flake8]
-ignore = F811
+# E123,E133,E226,E241,E242 are ignored by default by pep8 and flake8
+# F811 is legal in odoo 8 when we implement 2 interfaces for a method
+ignore = E123,E133,E226,E241,E242,F811
 max-line-length = 79
 exclude = __unported__,__init__.py

--- a/travis/cfg/travis_run_flake8__init__.cfg
+++ b/travis/cfg/travis_run_flake8__init__.cfg
@@ -1,5 +1,7 @@
 [flake8]
-ignore = F401
+# E123,E133,E226,E241,E242 are ignored by default by pep8 and flake8
+# F401 is legal in odoo __init__.py files
+ignore = E123,E133,E226,E241,E242,F401
 max-line-length = 79
 exclude = __unported__
 filename = __init__.py


### PR DESCRIPTION
Fix a regression when specifying the error codes to ignore for flake8 / pep8.
The error codes which are ignored by default must be added manually to
stay close to the default behaviour of pep8 and flake8.
