### PR TITLE
Revert "[REF][pylint.cfg] Active errors E1101, W0104, W0105, W0109, W040...

### DIFF
--- a/travis/cfg/travis_run_pylint.cfg
+++ b/travis/cfg/travis_run_pylint.cfg
@@ -1,12 +1,12 @@
 [MASTER]
 profile=no
-ignore=CVS,.git,scenarios,.bzr,__openerp__.py,__odoo__.py,__terp__.py
+ignore=CVS,.git,scenarios,.bzr
 persistent=yes
 cache-size=500
 
 [MESSAGES CONTROL]
 disable=all
-enable=E0101,E1101,E1124,E1306,I0013,W0101,W0102,W0104,W0105,W0109,W0403,W0404,W0621,W0622,W1111,W1401
+enable=E0101,E1124,E1306,I0013,W0101,W1111,W0102
 
 [REPORTS]
 msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}

--- a/travis/getaddons.py
+++ b/travis/getaddons.py
@@ -13,7 +13,7 @@ import sys
 def is_module(path):
     if not os.path.isdir(path):
         return False
-    manifs = ['__openerp__.py', '__odoo__.py', '__terp__.py', '__init__.py']
+    manifs = ['__openerp__.py', '__odoo__.py', '__terp.py__', '__init__.py']
     files = os.listdir(path)
     filtered = [x for x in files if x in manifs]
     res = len(filtered) == 2 and '__init__.py' in filtered


### PR DESCRIPTION
Reverts OCA/maintainer-quality-tools#110

E1101 check cause that all branches goes red, so we must revert ASAP. Please see https://github.com/OCA/maintainer-quality-tools/issues/119 for an explanation.
