### PR TITLE
Install lxml using pip instead of apt-get

### DIFF
--- a/travis/requirements.txt
+++ b/travis/requirements.txt
@@ -7,7 +7,7 @@ gdata
 gevent
 psycogreen
 Jinja2
-#lxml - installed using apt-get
+lxml
 mako
 mock
 passlib

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -15,7 +15,6 @@ wget -O odoo.tar.gz ${ODOO_URL}
 tar -xf odoo.tar.gz -C ${HOME}
 
 sudo apt-get -q install expect-dev  # provides unbuffer utility
-sudo apt-get -q install python-lxml  # because pip installation is slooow
 
 pip install -q QUnitSuite flake8 coveralls pylint
 pip install -q -r $(dirname ${BASH_SOURCE[0]})/requirements.txt


### PR DESCRIPTION
This allows for tests to run in isolated virtualenvs.
It is the case for shippable.com CI.
