### PR TITLE
Force using system site packages in the virtualenv

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -14,8 +14,8 @@ echo "Installing Odoo ${ODOO_URL}"
 wget -O odoo.tar.gz ${ODOO_URL}
 tar -xf odoo.tar.gz -C ${HOME}
 
-sudo apt-get -q install expect-dev  # provides unbuffer utility
-sudo apt-get -q install python-lxml  # because pip installation is slooow
+sudo apt-get -q -y install expect-dev  # provides unbuffer utility
+sudo apt-get -q -y install python-lxml  # because pip installation is slooow
 
 # Workaround to force using system site packages (see https://github.com/Shippable/support/issues/241#issuecomment-57947925)
 rm $VIRTUAL_ENV/lib/python2.7/no-global-site-packages.txt


### PR DESCRIPTION
Workaround for sippable.com lack of support for the
--system-site-packages, as per
https://github.com/Shippable/support/issues/241
