### PR TITLE
[ADD] shippable_install_nightly: Add compatibility for shippable

### DIFF
--- a/travis/shippable_install_nightly
+++ b/travis/shippable_install_nightly
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+sudo mkdir -p /etc/ssl/private-copy; sudo mkdir -p /etc/ssl/private; sudo mv /etc/ssl/private/* /etc/ssl/private-copy/; sudo rm -r /etc/ssl/private; sudo mv /etc/ssl/private-copy /etc/ssl/private; sudo chmod -R 0700 /etc/ssl/private; sudo chown -R postgres /etc/ssl/private
+sudo su -c "sudo -u postgres /usr/lib/postgresql/9.3/bin/postgres -c "config_file=/etc/postgresql/9.3/main/postgresql.conf" > /tmp/pg.log 2>&1 & sleep 5s"
+find ${HOME} -name server.py -exec sed -i \"s/== 'root'/== 'force_root'/g\" {} \;
+
+# Workaround to force using system site packages (see https://github.com/Shippable/support/issues/241#issuecomment-57947925)
+rm -rf $VIRTUAL_ENV/lib/python2.7/no-global-site-packages.txt

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -17,12 +17,13 @@ tar -xf odoo.tar.gz -C ${HOME}
 sudo apt-get -q -y install expect-dev  # provides unbuffer utility
 sudo apt-get -q -y install python-lxml  # because pip installation is slooow
 
-# Workaround to force using system site packages (see https://github.com/Shippable/support/issues/241#issuecomment-57947925)
-rm $VIRTUAL_ENV/lib/python2.7/no-global-site-packages.txt
-
 pip install -q QUnitSuite flake8 coveralls pylint
 pip install -q -r $(dirname ${BASH_SOURCE[0]})/requirements.txt
 
+if [ "${SHIPPABLE}" == "true" ] ; then
+    echo "Installing for shippable"
+    $(dirname ${BASH_SOURCE[0]})/shippable_install_nightly
+fi
 # Use reference .coveragerc
 cp ${HOME}/maintainer-quality-tools/cfg/.coveragerc .
 


### PR DESCRIPTION
Travis today is down.
We need other CI tool.

Shippable is a good option.
  -Work with .travis.yml file.

To test it we will need that a 
[owner](https://github.com/orgs/OCA/teams/owners) 
  @jgrandguillaume 
  @StefanRijnhart 
  @gurneyalex 
Make a user with shippable and enable MQT repo, please.
![descarga](https://cloud.githubusercontent.com/assets/6644187/5258849/b07ee6b4-79bc-11e4-80d5-8904e35160fd.png)
