### PR TITLE
Pin werkzeug on stable 0.9 versions

### DIFF
--- a/travis/requirements.txt
+++ b/travis/requirements.txt
@@ -31,5 +31,5 @@ simplejson
 unittest2
 vatnumber
 vobject
-werkzeug
+werkzeug < 0.10
 xlwt


### PR DESCRIPTION
The new werkzeug series 0.10 released on 2015-01-29 break the API compatibility, we should stay on 0.9 series as it already crash on tests: https://travis-ci.org/petrus-v/server-tools/jobs/49292789
```
2015-02-03 09:42:28,065 23608 INFO openerp_test openerp.service.server: Initiating shutdown
2015-02-03 09:42:28,065 23608 INFO openerp_test openerp.service.server: Hit CTRL-C again or send a second signal to force the shutdown.
Traceback (most recent call last):
File "/home/travis/odoo-8.0/openerp-server", line 5, in <module>
openerp.cli.main()
File "/home/travis/odoo-8.0/openerp/cli/__init__.py", line 71, in main
o.run(args)
File "/home/travis/odoo-8.0/openerp/cli/server.py", line 174, in run
main(args)
File "/home/travis/odoo-8.0/openerp/cli/server.py", line 168, in main
rc = openerp.service.server.start(preload=preload, stop=stop)
File "/home/travis/odoo-8.0/openerp/service/server.py", line 942, in start
rc = server.run(preload, stop)
File "/home/travis/odoo-8.0/openerp/service/server.py", line 352, in run
self.stop()
File "/home/travis/odoo-8.0/openerp/service/server.py", line 320, in stop
self.close_socket(self.httpd.socket)
File "/home/travis/odoo-8.0/openerp/service/server.py", line 213, in close_socket
sock.shutdown(socket.SHUT_RDWR)
File "/usr/lib/python2.7/socket.py", line 224, in meth
return getattr(self._sock,name)(*args)
File "/usr/lib/python2.7/socket.py", line 170, in _dummy
raise error(EBADF, 'Bad file descriptor')
error: [Errno 9] Bad file descriptor
```