### PR TITLE
[IMP] only take a shallow copy of branches we need, add VERSION to lint

### DIFF
--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
 
 env:
-  - LINT_CHECK="1"
+  - VERSION="8.0" LINT_CHECK="1"
   - VERSION="8.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
   - VERSION="8.0" ODOO_REPO="OCA/OCB" LINT_CHECK="0"
   - VERSION="8.0" ODOO_REPO="odoo/odoo" UNIT_TEST="1" LINT_CHECK="0"
@@ -13,11 +13,11 @@ virtualenv:
   system_site_packages: true
 
 install:
-  - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
+  - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
 # example: dependency
-# - git clone https://github.com/OCA/webkit-tools -b ${VERSION} $HOME/webkit-tools
+# - git clone --depth=1 https://github.com/OCA/webkit-tools -b ${VERSION} $HOME/webkit-tools
 
 script:
   - travis_run_tests

--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -7,7 +7,12 @@ env:
   - VERSION="8.0" LINT_CHECK="1"
   - VERSION="8.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
   - VERSION="8.0" ODOO_REPO="OCA/OCB" LINT_CHECK="0"
-  - VERSION="8.0" ODOO_REPO="odoo/odoo" UNIT_TEST="1" LINT_CHECK="0"
+# either use the two lines above or the two below. Don't change the default if
+# it's not necessary (it is only necessary if modules in your repository can't
+# be installed in the same database. And you get a huge speed penalty in your
+# tests)
+#  - VERSION="8.0" ODOO_REPO="odoo/odoo" UNIT_TEST="1" LINT_CHECK="0"
+#  - VERSION="8.0" ODOO_REPO="OCA/OCB" UNIT_TEST="1" LINT_CHECK="0"
 
 virtualenv:
   system_site_packages: true


### PR DESCRIPTION
The version variable in the link check case is necessary because getting dependencies errors out otherwise