### PR TITLE
[IMP] Added git pre-commit script hook for checking flake8 and pylint

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -17,10 +17,11 @@ For using it, you can choose from two options:
 Then, making `git init` inside a git repository, these files will be copied,
 and you will have these checks available for it.
 
-**IMPORTANT** Don't forget to update pep8 and pylint modules to have the same
-checks as Travis. Don't use distribution packages, are they are outdated. Use
-pip ones:
+**IMPORTANT** Don't forget to install/update flake8, pep8 and pylint modules to
+have the same checks as Travis. Don't use distribution packages, as they are 
+outdated. Use pip ones:
 ```
+sudo pip install flake8 --upgrade
 sudo pip install pep8 --upgrade
 sudo pip install pylint --upgrade
 ```

--- a/git/README.md
+++ b/git/README.md
@@ -1,0 +1,26 @@
+Script for making the same tests as in Travis before committing
+===============================================================
+
+This script allows to make a test before each commit you make on your local
+git repository, checking same things as in Travis PYLINT_CHECK phase of
+OCA maintainer quality tools.
+
+For using it, you can choose from two options:
+
+1. Copy files to local git repository into .git/hooks, and you will enable the
+   checks for that git repository.
+
+2. Copy files to git template directory. In Ubuntu, it's located in:
+
+   /usr/share/git-core/templates/hooks/
+
+Then, making `git init` inside a git repository, these files will be copied,
+and you will have these checks available for it.
+
+**IMPORTANT** Don't forget to update pep8 and pylint modules to have the same
+checks as Travis. Don't use distribution packages, are they are outdated. Use
+pip ones:
+```
+sudo pip install pep8 --upgrade
+sudo pip install pylint --upgrade
+```

--- a/git/README.md
+++ b/git/README.md
@@ -2,7 +2,7 @@ Script for making the same tests as in Travis before committing
 ===============================================================
 
 This script allows to make a test before each commit you make on your local
-git repository, checking same things as in Travis PYLINT_CHECK phase of
+git repository, checking same things as in Travis LINT_CHECK phase of
 OCA maintainer quality tools.
 
 For using it, you can choose from two options:
@@ -24,3 +24,6 @@ pip ones:
 sudo pip install pep8 --upgrade
 sudo pip install pylint --upgrade
 ```
+
+You can bypass these checks setting environment variable NOLINT before calling
+commit, e.g, `NOLINT=1 git commit`.

--- a/git/cfg
+++ b/git/cfg
@@ -1,0 +1,1 @@
+../travis/cfg/

--- a/git/pre-commit
+++ b/git/pre-commit
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+if [ "$NOLINT" ]; then exit 0; fi
+
 set -v
 
 FLAKE8_CONFIG_DIR="$(dirname $0)/cfg"

--- a/git/pre-commit
+++ b/git/pre-commit
@@ -22,7 +22,7 @@ export PYTHONPATH=${PYTHONPATH}:$GIT_DIR
 touch $GIT_DIR/__init__.py
 
 # run pylint command - For some strange reason, message controls are not taken correctly from cfg
-pylint --rcfile=${PYLINT_CONFIG_DIR}/travis_run_pylint.cfg --disable=all --enable=E0101,E1124,E1306,E1601,I0013,W0101,W0102,W0104,W0105,W0109,W0403,W0404,W1111,W1401 $GIT_DIR
+pylint --rcfile=${PYLINT_CONFIG_DIR}/travis_run_pylint.cfg --disable=all --enable=E0101,E1124,E1306,E1601,I0013,W0101,W0102,W0104,W0105,W0109,W0403,W0404,W1111,W1401 $GIT_DIR/*
 pylint_status=$?
 rm $GIT_DIR/__init__.py
 

--- a/git/pre-commit
+++ b/git/pre-commit
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -v
+
+FLAKE8_CONFIG_DIR="$(dirname $0)/cfg"
+
+flake8 . --config=${FLAKE8_CONFIG_DIR}/travis_run_flake8__init__.cfg
+status1=$?
+flake8 . --config=${FLAKE8_CONFIG_DIR}/travis_run_flake8.cfg
+status2=$?
+
+set -v
+
+PYLINT_CONFIG_DIR="$(dirname $0)/cfg"
+# In the structure, hooks are in .git/hooks, so we need to go 2 levels up
+GIT_DIR="$(dirname $(dirname $(dirname $0)))"
+
+# Fix pylint path. More info: https://www.mail-archive.com/code-quality@python.org/msg00294.html
+export PYTHONPATH=${PYTHONPATH}:$GIT_DIR
+touch $GIT_DIR/__init__.py
+
+# run pylint command - For some strange reason, message controls are not taken correctly from cfg
+pylint --rcfile=${PYLINT_CONFIG_DIR}/travis_run_pylint.cfg --disable=all --enable=E0101,E1124,E1306,E1601,I0013,W0101,W0102,W0104,W0105,W0109,W0403,W0404,W1111,W1401 $GIT_DIR
+pylint_status=$?
+rm $GIT_DIR/__init__.py
+
+exit $((${status1} || ${status2} || ${pylint_status}))


### PR DESCRIPTION
Script for making the same tests as in Travis before committing
===============================================================

This script allows to make a test before each commit you make on your local
git repository, checking same things as in Travis PYLINT_CHECK phase of
OCA maintainer quality tools.

For using it, you can make two options:

1. Copy files to local git repository into .git/hooks, and you will enable the
   checks for that git repository.

2. Copy files to git template directory. In Ubuntu, it's located in

   /usr/share/git-core/templates/hooks/

   Then, making `git init`  inside a git repository, these files will be copied,
   and you will have these checks available for it.