### PR TITLE
[FIX] Tests should be performed in update mode

### DIFF
--- a/travis/test_server
+++ b/travis/test_server
@@ -211,7 +211,7 @@ def main():
                          ]
         if test_loghandler is not None:
             cmd_odoo_test += ['--log-handler', test_loghandler]
-        cmd_odoo_test += options + ["--init", None]
+        cmd_odoo_test += options + ["--update", None]
         commands = ((cmd_odoo_test, True),
                     )
     all_errors = []


### PR DESCRIPTION
When the tests are launched, the modules to test are already installed. Therefore we should avoid to reinstall the modules to run the tests. (it's already the case with unittest=1)This will prevent some errors with xml data defiend with noupdate="1".  (https://travis-ci.org/OCA/l10n-belgium/jobs/54770816, https://github.com/acsone/l10n-belgium/blob/8.0-add-account_bank_statement_import_coda/account_bank_statement_import_coda/demo/demo_data.xml)