### PR TITLE
Remove pinned 8.0 test dependency

### DIFF
--- a/tests/test_repo/oca_dependencies.txt
+++ b/tests/test_repo/oca_dependencies.txt
@@ -1,5 +1,4 @@
 # List the OCA project dependencies, one per line
 # Add a repository url and branch if you need a forked version
 
-partner-contact https://github.com/OCA/partner-contact 8.0
-
+# partner-contact https://github.com/OCA/partner-contact 8.0

--- a/tests/test_repo/test_module/__openerp__.py
+++ b/tests/test_repo/test_module/__openerp__.py
@@ -4,7 +4,6 @@
     'version': '1.0',
     'depends': [
         'base',
-        'partner_auto_salesman'
     ],
     'data': [
         'security/ir.model.access.csv',


### PR DESCRIPTION
This makes test fail for previous versions (7.0, 6.1)
Fixes #173