### PR TITLE
Run coveralls conditionally

### DIFF
--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
   - VERSION="8.0"
   matrix:
-  - LINT_CHECK="1"
+  - LINT_CHECK="1" TESTS="0"
   - TESTS="1" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
   - TESTS="1" ODOO_REPO="OCA/OCB" LINT_CHECK="0"
 # either use the two lines above or the two below. Don't change the default if

--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -5,9 +5,12 @@ python:
   - "2.7"
 
 env:
-  - VERSION="8.0" LINT_CHECK="1"
-  - VERSION="8.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
-  - VERSION="8.0" ODOO_REPO="OCA/OCB" LINT_CHECK="0"
+  global:
+  - VERSION="8.0"
+  matrix:
+  - LINT_CHECK="1"
+  - TESTS="1" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
+  - TESTS="1" ODOO_REPO="OCA/OCB" LINT_CHECK="0"
 # either use the two lines above or the two below. Don't change the default if
 # it's not necessary (it is only necessary if modules in your repository can't
 # be installed in the same database. And you get a huge speed penalty in your
@@ -27,4 +30,4 @@ script:
   - travis_run_tests
 
 after_success:
-  coveralls
+  - travis_after_tests_success

--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -6,17 +6,17 @@ python:
 
 env:
   global:
-  - VERSION="8.0"
+  - VERSION="8.0" TESTS="0" LINT_CHECK="0"
   matrix:
-  - LINT_CHECK="1" TESTS="0"
-  - TESTS="1" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
-  - TESTS="1" ODOO_REPO="OCA/OCB" LINT_CHECK="0"
+  - LINT_CHECK="1"
+  - TESTS="1" ODOO_REPO="odoo/odoo"
+  - TESTS="1" ODOO_REPO="OCA/OCB"
 # either use the two lines above or the two below. Don't change the default if
 # it's not necessary (it is only necessary if modules in your repository can't
 # be installed in the same database. And you get a huge speed penalty in your
 # tests)
-#  - VERSION="8.0" ODOO_REPO="odoo/odoo" UNIT_TEST="1" LINT_CHECK="0"
-#  - VERSION="8.0" ODOO_REPO="OCA/OCB" UNIT_TEST="1" LINT_CHECK="0"
+#  - TESTS="1.0" ODOO_REPO="odoo/odoo" UNIT_TEST="1"
+#  - TESTS="1.0" ODOO_REPO="OCA/OCB" UNIT_TEST="1"
 
 virtualenv:
   system_site_packages: true

--- a/travis/travis_after_tests_success
+++ b/travis/travis_after_tests_success
@@ -5,6 +5,6 @@ set -v
 # if the env variable TESTS is not set, default to 1 to keep backward compatibility
 : ${TESTS:="1"}
 
-if [ "${TESTS}" = "1" ] ; then
+if [ "${TESTS}" = "1" ] && [ "${LINT_CHECK}" != "1" ] ; then
   coveralls
 fi

--- a/travis/travis_after_tests_success
+++ b/travis/travis_after_tests_success
@@ -1,10 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env python
 
-set -v
+import os
+from coveralls import cli as coveralls_cli
 
-# if the env variable TESTS is not set, default to 1 to keep backward compatibility
-: ${TESTS:="1"}
-
-if [ "${TESTS}" = "1" ] && [ "${LINT_CHECK}" != "1" ] ; then
-  coveralls
-fi
+if os.environ.get('TESTS', True) and not os.environ.get('LINT_CHECK'):
+    exit(coveralls_cli.main(argv=None))

--- a/travis/travis_after_tests_success
+++ b/travis/travis_after_tests_success
@@ -3,5 +3,6 @@
 import os
 from coveralls import cli as coveralls_cli
 
-if os.environ.get('TESTS', True) and not os.environ.get('LINT_CHECK'):
+if (os.environ.get('TESTS', '1') == '1' and
+        not os.environ.get('LINT_CHECK') == '1'):
     exit(coveralls_cli.main(argv=None))

--- a/travis/travis_after_tests_success
+++ b/travis/travis_after_tests_success
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -v
+
+# if the env variable TESTS is not set, default to 1 to keep backward compatibility
+: ${TESTS:="1"}
+
+if [ "${TESTS}" = "1" ] ; then
+  coveralls
+fi

--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -8,6 +8,7 @@ import subprocess
 import sys
 from travis_helpers import success_msg, fail_msg
 
+
 def main(test_list):
     args = sys.argv[1:]
     results = []
@@ -27,7 +28,7 @@ def main(test_list):
         print("| {0:<28}{1}".format(desc, outcome))
     print("+" + "="*39)
 
-    return(max(results))
+    return max(results)
 
 
 if __name__ == '__main__':
@@ -41,4 +42,5 @@ if __name__ == '__main__':
     if (os.environ.get("LINT_CHECK") != "1" and
             os.environ.get("TESTS", "1") == "1"):
         tests.append(['test_server'])
-    exit(main(tests))
+    if tests:
+        exit(main(tests))

--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -37,6 +37,8 @@ if __name__ == '__main__':
     if os.environ.get("LINT_CHECK", "1") == "1":
         tests.append(['test_flake8'])
         tests.append(['test_pylint'])
-    if os.environ.get("LINT_CHECK", None) != "1":
+    # Execute tests by default. Disable them on lint checks
+    if (os.environ.get("LINT_CHECK") != "1" and
+            os.environ.get("TESTS", "1") == "1"):
         tests.append(['test_server'])
     exit(main(tests))


### PR DESCRIPTION
Currently, the `coveralls` command runs on every build: the tests builds but the lint one as well.

Yesterday, I added a new build on OCA/connector#60 which builds the documentation; I added environment variables to switch off `coveralls` (https://github.com/OCA/connector/commit/bc55f9aab88927a75624778fd02922ab426264e6#diff-354f30a63fb0907d4ad57269548329e3R15).

After a few exchanges on Twitter with @bwrsandman and @pedrobaeza, I engaged myself to propose a change in the MQT to allow `coveralls` to run conditionnally. So here it is.

This PR is backward compatible. To be effective on the projects, we'll need to replace `coveralls` by `travis_after_tests_success` in all the `.travis.yml` files. If we agree on this change, I can make a script that creates pull requests for that (and in any case, until the line is changed, the builds will still continue to work as of today).

`coveralls` is now activated when the environment variable `TESTS` is `"1"`. As it is a new variable, it is set by default to `"1"` to be backward compatible. However, it allows to switch off the tests on a case by case basis. Example for the  build of the docs: OCA/connector#61

I also proposed an little improvement in the sample file by putting the version in `env: global:`, it don't need to be repeated on every lines (the result is exactly the same).