### PR TITLE
Add python libs to container directives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ addons:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml  # because pip installation is slow
+      - python-simplejson
+      - python-serial
 
 virtualenv:
   system_site_packages: true

--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -8,6 +8,8 @@ addons:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml  # because pip installation is slow
+      - python-simplejson
+      - python-serial
 
 env:
   global:


### PR DESCRIPTION
This should speed up the container based builds by taking time out of the pip install command and using ready-made containers which add virtually no time.

These packages were not taken out of travis/requirements.txt for backwards compatibility. The speedup should still be there since in those cases, pip will see the dependency installed and not attempt to install them.