### PR TITLE
Transifex create options

### DIFF
--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -21,9 +21,11 @@ env:
   # The default project slug is owner-repo_name-version (with dash in the version string).
   # The default organization is the owner of the repo.
   # The default fill up resources (TM) is True.
+  # The default team is 23907. https://www.transifex.com/organization/oca/team/23907/
   # - TRANSIFEX_PROJECT_SLUG=
   # - TRANSIFEX_ORGANIZATION=
   # - TRANSIFEX_FILL_UP_RESOURCES=
+  # - TRANSIFEX_TEAM=
 
   matrix:
   - LINT_CHECK="1"

--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -20,8 +20,10 @@ env:
   # Use the following lines if you need to manually change the transifex project slug or/and the transifex organization.
   # The default project slug is owner-repo_name-version (with dash in the version string).
   # The default organization is the owner of the repo.
+  # The default fill up resources (TM) is True.
   # - TRANSIFEX_PROJECT_SLUG=
   # - TRANSIFEX_ORGANIZATION=
+  # - TRANSIFEX_FILL_UP_RESOURCES=
 
   matrix:
   - LINT_CHECK="1"

--- a/travis/travis_transifex.py
+++ b/travis/travis_transifex.py
@@ -60,6 +60,9 @@ def main(argv=None):
     transifex_project_name = "%s (%s)" % (travis_repo_shortname, odoo_version)
     transifex_organization = os.environ.get("TRANSIFEX_ORGANIZATION",
                                             travis_repo_owner)
+    transifex_fill_up_resources = os.environ.get(
+        "TRANSIFEX_FILL_UP_RESOURCES", "True"
+    )
     repository_url = "https://github.com/%s" % travis_repo_slug
 
     odoo_full = os.environ.get("ODOO_REPO", "odoo/odoo")
@@ -89,6 +92,7 @@ def main(argv=None):
                     "repository_url": repository_url,
                     "organization": transifex_organization,
                     "license": "permissive_open_source",
+                    "fill_up_resources": transifex_fill_up_resources,
                     }
     try:
         api.project(transifex_project_slug).get()

--- a/travis/travis_transifex.py
+++ b/travis/travis_transifex.py
@@ -63,6 +63,9 @@ def main(argv=None):
     transifex_fill_up_resources = os.environ.get(
         "TRANSIFEX_FILL_UP_RESOURCES", "True"
     )
+    transifex_team = os.environ.get(
+        "TRANSIFEX_TEAM", "23907"
+    )
     repository_url = "https://github.com/%s" % travis_repo_slug
 
     odoo_full = os.environ.get("ODOO_REPO", "odoo/odoo")
@@ -93,6 +96,7 @@ def main(argv=None):
                     "organization": transifex_organization,
                     "license": "permissive_open_source",
                     "fill_up_resources": transifex_fill_up_resources,
+                    "team": transifex_team,
                     }
     try:
         api.project(transifex_project_slug).get()


### PR DESCRIPTION
Following @pedrobaeza's [suggestion](https://github.com/OCA/maintainer-quality-tools/issues/194#issuecomment-104869668), two more options to transifex creation have been adeed.

These can be overridden in the `.travis.yml` environment section.
* `TRANSIFEX_FILL_UP_RESOURCES`, default ~~False~~ True, activates TM at creation
* `TRANSIFEX_TEAM`, default [23907](https://www.transifex.com/organization/oca/team/23907/), joins the OCA team at creation instead of creating another

~~The default for `TRANSIFEX_FILL_UP_RESOURCES` is up for debate, I will change it to True if enough people want it. Personally I would rather not have auto fill of terms to 100% if they're done automatically.~~