### PR TITLE
Use svg badge for coveralls

### DIFF
--- a/sample_files/README.md
+++ b/sample_files/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/OCA/${REPO_NAME}.svg?branch=${BRANCH_NAME})](https://travis-ci.org/OCA/${REPO_NAME})
-[![Coverage Status](https://coveralls.io/repos/OCA/${REPO_NAME}/badge.png?branch=${BRANCH_NAME})](https://coveralls.io/r/OCA/${REPO_NAME}?branch=${BRANCH_NAME})
+[![Coverage Status](https://coveralls.io/repos/OCA/${REPO_NAME}/badge.svg?branch=${BRANCH_NAME})](https://coveralls.io/r/OCA/${REPO_NAME}?branch=${BRANCH_NAME})
 
 # ${REPO_NAME_VERBOSE}
 


### PR DESCRIPTION
SVG badge matches the styles of other README badges such as build status

See the difference here for example: https://github.com/OCA/vertical-isp/commit/c6a40aa4cdb9808ecde0e8d6fa3208a13016efdb?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8

PNG: [![Coverage Status](https://coveralls.io/repos/OCA/vertical-isp/badge.png?branch=7.0)](https://coveralls.io/r/OCA/vertical-isp?branch=7.0)
SVG: [![Coverage Status](https://coveralls.io/repos/OCA/vertical-isp/badge.svg?branch=7.0)](https://coveralls.io/r/OCA/vertical-isp?branch=7.0)
Build Status: [![Build Status](https://travis-ci.org/OCA/vertical-isp.svg?branch=7.0)](https://travis-ci.org/OCA/vertical-isp)