### PR TITLE
Reactivate python coverage on MQT itself

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
+[run]
+data_file = .coverage_mqt  # to avoid being overridden by server tests
+
 [report]
 # Regexes for lines to exclude from consideration
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 data_file = .coverage_mqt  # to avoid being overridden by server tests
+omit = *system_site_packages*
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ install:
   - travis_install_nightly 8.0 # only used if VERSION not set in env
 
 script:
-  - coverage run ./travis/self_tests
-  - coverage run ./travis/travis_run_tests 8.0  # only used if VERSION not set in env
+  - coverage run --append ./travis/self_tests
+  - coverage run --append ./travis/travis_run_tests 8.0  # only used if VERSION not set in env
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ install:
   - travis_install_nightly 8.0 # only used if VERSION not set in env
 
 script:
-  - self_tests
-  - travis_run_tests 8.0  # only used if VERSION not set in env
+  - coverage run ./travis/self_tests
+  - coverage run ./travis/travis_run_tests 8.0  # only used if VERSION not set in env
 
-#after_success:
-#  coveralls
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/OCA/maintainer-quality-tools.svg)](https://travis-ci.org/OCA/maintainer-quality-tools)
+[![Coverage Status](https://coveralls.io/repos/OCA/maintainer-quality-tools/badge.svg)](https://coveralls.io/r/OCA/maintainer-quality-tools)
 
 QA Tools for Odoo maintainers
 =============================

--- a/travis/getaddons.py
+++ b/travis/getaddons.py
@@ -48,11 +48,13 @@ def get_addons(path):
     return res
 
 
-if __name__ == "__main__":
-    params = sys.argv[1:]
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv
+    params = argv[1:]
     if not params:
         print(__doc__)
-        sys.exit(1)
+        return 1
 
     list_modules = False
     exclude_modules = []
@@ -70,3 +72,6 @@ if __name__ == "__main__":
     if exclude_modules:
         res = [x for x in res if x not in exclude_modules]
     print(','.join(res))
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/travis/self_tests
+++ b/travis/self_tests
@@ -1,12 +1,25 @@
 #!/usr/bin/env python
 
 import os
+import getaddons
 from test_server import get_test_dependencies
 
 
-repo_dir = os.environ.get("TRAVIS_BUILD_DIR", "../tests/test_repo/")
+repo_dir = os.environ.get("TRAVIS_BUILD_DIR", "./tests/test_repo/")
+exclude = os.environ.get("EXCLUDE")
+
 addons_list = ['test_module', 'second_module']
 to_preinstall = get_test_dependencies(repo_dir, addons_list)
 
 assert not [x for x in to_preinstall if x in addons_list], \
     "Should not preinstall modules to test!"
+
+# Testing getaddons
+assert getaddons.main() == 1
+getaddons.main(["getaddons.py", repo_dir])
+getaddons.main(["getaddons.py", "-m", repo_dir])
+getaddons.main(["getaddons.py", "-m",
+                repo_dir + "/" if repo_dir[-1] == '/' else repo_dir])
+if exclude:
+    getaddons.main(["getaddons.py", "-m", repo_dir, "-e", exclude])
+    getaddons.main(["getaddons.py", "-e", exclude, repo_dir])

--- a/travis/self_tests
+++ b/travis/self_tests
@@ -2,6 +2,7 @@
 
 import os
 import getaddons
+import travis_helpers
 from test_server import get_test_dependencies
 
 
@@ -23,3 +24,9 @@ getaddons.main(["getaddons.py", "-m",
 if exclude:
     getaddons.main(["getaddons.py", "-m", repo_dir, "-e", exclude])
     getaddons.main(["getaddons.py", "-e", exclude, repo_dir])
+
+# Testing travis helpers
+assert travis_helpers.red(u'test') == u"\033[1;31mtest\033[0;m"
+assert travis_helpers.green(u'test') == u"\033[1;32mtest\033[0;m"
+assert travis_helpers.yellow(u'test') == u"\033[1;33mtest\033[0;m"
+assert travis_helpers.yellow_light(u'test') == u"\033[33mtest\033[0;m"

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -199,7 +199,9 @@ def setup_server(db, odoo_unittest, tested_addons, server_path,
     return 0
 
 
-def main():
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv
     travis_home = os.environ.get("HOME", "~/")
     travis_build_dir = os.environ.get("TRAVIS_BUILD_DIR", "../..")
     odoo_unittest = str2bool(os.environ.get("UNIT_TEST"))
@@ -212,7 +214,7 @@ def main():
     if not odoo_version:
         # For backward compatibility, take version from parameter
         # if it's not globally set
-        odoo_version = sys.argv[1]
+        odoo_version = argv[1]
         print("WARNING: no env variable set for VERSION. "
               "Using '%s'" % odoo_version)
     test_loghandler = None

--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -10,13 +10,30 @@ from travis_helpers import success_msg, fail_msg
 
 
 def main(test_list):
+    """
+    Loop through each test and run them, add display results at the end
+
+    If the test has a .py extension, import as a list and call main function
+
+    :param list test_list: list of lists containing commands to run
+    :return: highest error code
+    """
     args = sys.argv[1:]
     results = []
     for test in test_list:
         # keep backward compatibility with version as an argument
         print("======== Testing %s ========" % test[0])
         test_w_args = test + args
-        res = subprocess.call(test_w_args)
+        test_file = test_w_args[0]
+        if test_file.endswith(".py"):
+            test_lib = test_file[:-3]
+            try:
+                res = __import__(test_lib).main(argv=test_w_args)
+            except Exception as e:
+                print(e)
+                res = 1
+        else:
+            res = subprocess.call(test_w_args)
         results.append(res)
 
     print()


### PR DESCRIPTION
The point in #35 is no longer the case since most tests are python.

Improve coverage of getaddons.py and bring overall coverage to about 90%