### PR TITLE
[IMP] pip --user argument to make travis .NET build work

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -24,7 +24,7 @@ tar -xf odoo.tar.gz -C ${HOME}
 # Workaround to force using system site packages (see https://github.com/Shippable/support/issues/241#issuecomment-57947925)
 rm -f $VIRTUAL_ENV/lib/python2.7/no-global-site-packages.txt
 
-pip install -q -r $(dirname ${BASH_SOURCE[0]})/requirements.txt
+pip install --user -q -r $(dirname ${BASH_SOURCE[0]})/requirements.txt
 
 # Use reference .coveragerc
 cp ${HOME}/maintainer-quality-tools/cfg/.coveragerc .


### PR DESCRIPTION
this fixes my install bugs for odoo + .NET build with mono, on 1 system
e.g. see [here](https://travis-ci.org/mathi123/dotnet/builds/68430398)