### PR TITLE
[REF] test_server: Print full command executed

### DIFF
--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -268,9 +268,9 @@ def main():
         subprocess.call(["createdb", "-T", dbtemplate, database])
         for command, check_loaded in commands:
             command[-1] = to_test
-            print(' '.join(command))
             # Run test command; unbuffer keeps output colors
             command_call = ["unbuffer"] + command
+            print(' '.join(command_call))
             pipe = subprocess.Popen(command_call,
                                     stderr=subprocess.STDOUT,
                                     stdout=subprocess.PIPE)


### PR DESCRIPTION
With docker I had a error of `command not found` my last print: `coverage run...`
```python
coverage run /root/odoo-8.0/openerp-server -d openerp_test --stop-after-init --log-level info --addons-path /root/myproject/lodigroup,/root/odoo-mexico-v2,/root/addons-vauxoo,/root/odoo-afr,/root/account-financial-tools,/root/odoo-ifrs,/root/server-tools,/root/odoo-8.0/addons --log-handler openerp.tools.yaml_import:DEBUG --test-enable --update lodi
Traceback (most recent call last):
  File "/root/maintainer-quality-tools/travis/test_server", line 278, in <module>
    exit(main())
  File "/root/maintainer-quality-tools/travis/test_server", line 239, in main
    stdout=subprocess.PIPE)
  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```
But I executed this command directly and work fine!
Later I saw that the command not found was `unbuffer`.
Because now is installed from [.travis.yml](https://github.com/OCA/maintainer-quality-tools/blob/master/.travis.yml#L12).

This PR fix the real command of last print.