### PR TITLE
Preinstall dependencies and run tests with --init instead of --upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ install:
   - travis_install_nightly 8.0 # only used if VERSION not set in env
 
 script:
+  - self_tests
   - travis_run_tests 8.0  # only used if VERSION not set in env
 
 #after_success:

--- a/tests/test_repo/second_module/__openerp__.py
+++ b/tests/test_repo/second_module/__openerp__.py
@@ -3,5 +3,7 @@
     'name': 'Second empty module for tests',
     'version': '1.0',
     'depends': [
-        'base'],
+        'base',
+        'test_module',
+        ],
 }

--- a/travis/self_tests
+++ b/travis/self_tests
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+import os
+from test_server import get_test_dependencies
+
+
+repo_dir = os.environ.get("TRAVIS_BUILD_DIR", "../tests/test_repo/")
+addons_list = ['test_module', 'second_module']
+to_preinstall = get_test_dependencies(repo_dir, addons_list)
+
+assert not [x for x in to_preinstall if x in addons_list], \
+    "Should not preinstall modules to test!"


### PR DESCRIPTION
Currently the database setup phase install all modules, and tests are run with a second command, using an upgrade.

This has a couple of issues:
  * In some cases tests during an upgrade have different results from tests during and install.
  * Init hooks don't run during an upgrade and their code is reported as not being covered by tests.

This PR changes the tests, so that only the core an external module dependencies are preinstalled in the setup phase, so the repo module tests can be executed with a `--init` instead of `--update`.
