### PR TITLE
fix #213: handle all lint/test cases, refactor

### DIFF
--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -50,7 +50,7 @@ if __name__ == '__main__':
     if tests_unspecified and not lint_check_enabled:
         tests.append(['test_server.py'])
 
-    if tests_enabled:
+    elif tests_enabled:
         tests.append(['test_server.py'])
 
     if transifex_enabled and not is_pull_request:

--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -31,24 +31,31 @@ def main(test_list):
 
 
 if __name__ == '__main__':
-    do_lint_check = os.environ.get("LINT_CHECK", '1') == "1"
-    do_tests = os.environ.get("TESTS", '1') == "1"
-    export_transifex = os.environ.get("TRANSIFEX") == "1"
-    # Variable TRAVIS_PULL_REQUEST corresponds to pull request number if the
-    # current job is a pull request, "false" if it's not a pull request.
-    travis_pull_request = os.environ.get("TRAVIS_PULL_REQUEST")
+    lint_check_disabled = os.environ.get('LINT_CHECK') == '0'
+    lint_check_enabled = os.environ.get('LINT_CHECK') == '1'
+    tests_enabled = os.environ.get('TESTS') == '1'
+    tests_disabled = os.environ.get('TESTS') == '0'
+    tests_unspecified = os.environ.get('TESTS') is None
+    travis_enabled = os.environ.get('TRANSIFEX') == '1'
+    transifex_enabled = os.environ.get('TRANSIFEX') == '1'
+
+    # TRAVIS_PULL_REQUEST contains the pull request number or 'false'
+    is_pull_request = os.environ.get('TRAVIS_PULL_REQUEST') != 'false'
 
     # Test list. Each test is a list with command + arguments.
     tests = []
-    # By default, do lint checks
-    if do_lint_check:
+
+    if not lint_check_disabled:
         tests.append(['test_flake8'])
         tests.append(['test_pylint'])
-    # Execute tests by default. Disable them on lint checks
-    if not do_lint_check and do_tests:
+
+    if tests_unspecified and not lint_check_enabled:
         tests.append(['test_server.py'])
-    # Execute transifex export with no tests and if it's an official commit
-    if not tests and export_transifex and travis_pull_request == "false":
+
+    if tests_enabled:
+        tests.append(['test_server.py'])
+
+    if transifex_enabled and not tests_disabled and not is_pull_request:
         tests.append(['travis_transifex.py'])
     if tests:
         exit(main(tests))

--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -55,7 +55,8 @@ if __name__ == '__main__':
     if tests_enabled:
         tests.append(['test_server.py'])
 
-    if transifex_enabled and not tests_disabled and not is_pull_request:
+    if transifex_enabled and not is_pull_request:
         tests.append(['travis_transifex.py'])
+
     if tests:
         exit(main(tests))

--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -34,9 +34,7 @@ if __name__ == '__main__':
     lint_check_disabled = os.environ.get('LINT_CHECK') == '0'
     lint_check_enabled = os.environ.get('LINT_CHECK') == '1'
     tests_enabled = os.environ.get('TESTS') == '1'
-    tests_disabled = os.environ.get('TESTS') == '0'
     tests_unspecified = os.environ.get('TESTS') is None
-    travis_enabled = os.environ.get('TRANSIFEX') == '1'
     transifex_enabled = os.environ.get('TRANSIFEX') == '1'
 
     # TRAVIS_PULL_REQUEST contains the pull request number or 'false'


### PR DESCRIPTION
fix #213: no tests only with explicit LINT_CHECK

We are trying to handle many different situations here:

- a .travis.yml that always sets variables to 0 or 1, like the one in
  samples/.travis.yml (4 cases)
- a line that has no options at all (it should lint, then test)
- a line that has only LINT_CHECK=1 (special case: it should not run
  tests)
- a line that has only LINT_CHECK=0 (special case: it should only run
  tests)

That makes a total of 7 cases that should all be handled here.

See #213 for a discussion on how to make all that more explicit (will
require an update in all .travis.yml files).