### PR TITLE
[IMP] search all addon paths for the modules to test

### DIFF
--- a/travis/getaddons.py
+++ b/travis/getaddons.py
@@ -10,12 +10,14 @@ import os
 import sys
 
 
+manifest_files = ['__openerp__.py', '__odoo__.py', '__terp__.py']
+
+
 def is_module(path):
     if not os.path.isdir(path):
         return False
-    manifs = ['__openerp__.py', '__odoo__.py', '__terp__.py', '__init__.py']
     files = os.listdir(path)
-    filtered = [x for x in files if x in manifs]
+    filtered = [x for x in files if x in (manifest_files + ['__init__.py'])]
     res = len(filtered) == 2 and '__init__.py' in filtered
     return res
 

--- a/travis/getaddons.py
+++ b/travis/getaddons.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 
-MANIFEST_FILES = ['__openerp__.py', '__odoo__.py', '__terp__.py']
+MANIFEST_FILES = ['__odoo__.py', '__openerp__.py', '__terp__.py']
 
 
 def is_module(path):
@@ -23,7 +23,7 @@ def is_module(path):
     filtered = [x for x in files if x in (MANIFEST_FILES + ['__init__.py'])]
     if len(filtered) == 2 and '__init__.py' in filtered:
         return os.path.join(
-            path, [x for x in filtered if x != '__init__.py'][0])
+            path, next(x for x in filtered if x != '__init__.py']))
     else:
         return False
 

--- a/travis/getaddons.py
+++ b/travis/getaddons.py
@@ -23,7 +23,7 @@ def is_module(path):
     filtered = [x for x in files if x in (MANIFEST_FILES + ['__init__.py'])]
     if len(filtered) == 2 and '__init__.py' in filtered:
         return os.path.join(
-            path, next(x for x in filtered if x != '__init__.py']))
+            path, next(x for x in filtered if x != '__init__.py'))
     else:
         return False
 

--- a/travis/getaddons.py
+++ b/travis/getaddons.py
@@ -10,14 +10,14 @@ import os
 import sys
 
 
-manifest_files = ['__openerp__.py', '__odoo__.py', '__terp__.py']
+MANIFEST_FILES = ['__openerp__.py', '__odoo__.py', '__terp__.py']
 
 
 def is_module(path):
     if not os.path.isdir(path):
         return False
     files = os.listdir(path)
-    filtered = [x for x in files if x in (manifest_files + ['__init__.py'])]
+    filtered = [x for x in files if x in (MANIFEST_FILES + ['__init__.py'])]
     res = len(filtered) == 2 and '__init__.py' in filtered
     return res
 

--- a/travis/getaddons.py
+++ b/travis/getaddons.py
@@ -14,12 +14,18 @@ MANIFEST_FILES = ['__openerp__.py', '__odoo__.py', '__terp__.py']
 
 
 def is_module(path):
+    """return False if the path doesn't contain an odoo module, and the full
+    path to the module manifest otherwise"""
+
     if not os.path.isdir(path):
         return False
     files = os.listdir(path)
     filtered = [x for x in files if x in (MANIFEST_FILES + ['__init__.py'])]
-    res = len(filtered) == 2 and '__init__.py' in filtered
-    return res
+    if len(filtered) == 2 and '__init__.py' in filtered:
+        return os.path.join(
+            path, [x for x in filtered if x != '__init__.py'][0])
+    else:
+        return False
 
 
 def get_modules(path):

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -6,7 +6,7 @@ import re
 import os
 import subprocess
 import sys
-from getaddons import get_addons, get_modules, manifest_files
+from getaddons import get_addons, get_modules, MANIFEST_FILES
 from travis_helpers import success_msg, fail_msg
 
 
@@ -165,7 +165,7 @@ def get_test_dependencies(addons_path, addons_list):
         return ['base']
     else:
         for path in addons_path.split(','):
-            for manifest_file in manifest_files:
+            for manifest_file in MANIFEST_FILES:
                 manif_path = os.path.join(path, addons_list[0],
                                           manifest_file)
                 if not os.path.isfile(manif_path):

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -6,7 +6,7 @@ import re
 import os
 import subprocess
 import sys
-from getaddons import get_addons, get_modules, MANIFEST_FILES
+from getaddons import get_addons, get_modules, is_module
 from travis_helpers import success_msg, fail_msg
 
 
@@ -165,16 +165,14 @@ def get_test_dependencies(addons_path, addons_list):
         return ['base']
     else:
         for path in addons_path.split(','):
-            for manifest_file in MANIFEST_FILES:
-                manif_path = os.path.join(path, addons_list[0],
-                                          manifest_file)
-                if not os.path.isfile(manif_path):
-                    continue
-                manif = eval(open(manif_path).read())
-                return list(
-                    set(manif.get('depends', []))
-                    | set(get_test_dependencies(addons_path, addons_list[1:]))
-                    - set(addons_list))
+            manif_path = is_module(os.path.join(path, addons_list[0]))
+            if not manif_path:
+                continue
+            manif = eval(open(manif_path).read())
+            return list(
+                set(manif.get('depends', []))
+                | set(get_test_dependencies(addons_path, addons_list[1:]))
+                - set(addons_list))
 
 
 def setup_server(db, odoo_unittest, tested_addons, server_path,

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -158,7 +158,7 @@ def get_test_dependencies(addons_path, addons_list):
     """
     Get the list of core and external modules dependencies
     for the modules to test.
-    :param addons_path: comma separated list of addons paths
+    :param addons_path: string with a comma separated list of addons paths
     :param addons_list: list of the modules to test
     """
     if not addons_list:


### PR DESCRIPTION
When finding dependencies, search for modules in all addon paths - this is necessary for OCB travis tests, cf https://github.com/OCA/OCB/pull/287#issuecomment-125867121