### PR TITLE
[FIX] Fix transifex export bug due to modules not installed

### DIFF
--- a/travis/travis_transifex.py
+++ b/travis/travis_transifex.py
@@ -120,7 +120,7 @@ def main(argv=None):
     # Install the modules on the database
     database = "openerp_i18n"
     setup_server(database, odoo_unittest, addons, server_path, addons_path,
-                 install_options)
+                 install_options, addons_list)
 
     # Initialize Transifex project
     print()


### PR DESCRIPTION
The bug was due to the recent changes in the `setup_server` function.
If we don't set anything in `preinstalled_modules`, only `base` is installed. So the modules to translate aren't installed and the script cannot export their `.pot` file.