### PR TITLE
[REF] test_pylint: Enable C0103 to validate CamelCase class name. (For old version snake_case is allow it too)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,22 +26,24 @@ env:
   - VERSION="8.0" TESTS="1" LINT_CHECK="0"
 
   matrix:
-  - INCLUDE="broken_module" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
+  # Test for: YAML assert error; test snake case lint
+  - INCLUDE="broken_module,broken_snake_case" LINT_CHECK="1" EXPECTED_ERRORS="2"
   - EXCLUDE="broken_module" OPTIONS="--log-level=debug" INSTALL_OPTIONS="--log-level=info"
   - INCLUDE="test_module,second_module" UNIT_TEST="1"
-  - VERSION="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # ODOO_REPO usage example
+  # Tests for: version 7; OCB usage; snake case check not done for v7
+  - VERSION="7.0" INCLUDE="test_module,second_module,broken_snake_case" LINT_CHECK="1" ODOO_REPO="OCA/OCB"
   - VERSION="6.1" INCLUDE="test_module,second_module"
-  - LINT_CHECK="1" TESTS="0"
+  - LINT_CHECK="1" TESTS="0" EXPECTED_ERRORS="1"  # Lint error expected
 
 install:
   - cp -r ../maintainer-quality-tools/ $HOME
   - mv tests/test_repo/* ./
   - export PATH=$HOME/maintainer-quality-tools/travis:$PATH
-  - travis_install_nightly 8.0 # only used if VERSION not set in env
+  - travis_install_nightly
 
 script:
   - coverage run --append ./travis/self_tests
-  - coverage run --append ./travis/travis_run_tests 8.0  # only used if VERSION not set in env
+  - coverage run --append ./travis/travis_run_tests
 
 after_success:
   - coveralls

--- a/git/README.md
+++ b/git/README.md
@@ -28,3 +28,7 @@ sudo pip install pylint --upgrade
 
 You can bypass these checks setting environment variable NOLINT before calling
 commit, e.g, `NOLINT=1 git commit`.
+
+You can use a lint configuration setting environment variable VERSION with
+the number of version of odoo before calling
+commit, e.g, `VERSION=7.0 git commit`.

--- a/git/pre-commit
+++ b/git/pre-commit
@@ -21,8 +21,14 @@ GIT_DIR="$(dirname $(dirname $(dirname $0)))"
 export PYTHONPATH=${PYTHONPATH}:$GIT_DIR
 touch $GIT_DIR/__init__.py
 
+if [[ "${VERSION}" == 6.* ]] || [[ "${VERSION}" == 7.* ]] ; then
+    # snake_case and CamelCase allow it for old version
+    export CLASS_CASE='--class-rgx=([a-z_][a-z0-9_]{2,45})|([A-Z_][a-zA-Z0-9]{2,45})$'
+fi
+
+
 # run pylint command - For some strange reason, message controls are not taken correctly from cfg
-pylint --rcfile=${PYLINT_CONFIG_DIR}/travis_run_pylint.cfg --disable=all --enable=E0101,E1124,E1306,E1601,I0013,W0101,W0102,W0104,W0105,W0109,W0403,W0404,W1111,W1401 $GIT_DIR/*
+pylint --rcfile=${PYLINT_CONFIG_DIR}/travis_run_pylint.cfg --disable=all ${CLASS_CASE} --enable=C0103,E0101,E1124,E1306,E1601,I0013,W0101,W0102,W0104,W0105,W0109,W0403,W0404,W1111,W1401 $GIT_DIR/*
 pylint_status=$?
 rm $GIT_DIR/__init__.py
 

--- a/tests/test_repo/broken_snake_case/__init__.py
+++ b/tests/test_repo/broken_snake_case/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import model

--- a/tests/test_repo/broken_snake_case/__openerp__.py
+++ b/tests/test_repo/broken_snake_case/__openerp__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Test fail on snake case',
+    'version': '1.0',
+    'depends': ['base'],
+}

--- a/tests/test_repo/broken_snake_case/model.py
+++ b/tests/test_repo/broken_snake_case/model.py
@@ -1,0 +1,8 @@
+from openerp.osv import orm, fields
+
+
+class test_snake_case(orm.Model):
+    _name = "test.snake.case"
+    _columns = {
+        'name': fields.char('Title', 100),
+    }

--- a/travis/cfg/travis_run_pylint.cfg
+++ b/travis/cfg/travis_run_pylint.cfg
@@ -6,7 +6,7 @@ cache-size=500
 
 [MESSAGES CONTROL]
 disable=all
-enable=E0101,E1124,E1306,E1601,I0013,W0101,W0102,W0104,W0105,W0109,W0403,W0404,W1111,W1401,W0402
+enable=C0103,E0101,E1124,E1306,E1601,I0013,W0101,W0102,W0104,W0105,W0109,W0403,W0404,W1111,W1401,W0402
 
 [REPORTS]
 msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
@@ -18,6 +18,17 @@ comment=no
 
 [FORMAT]
 indent-string='    '
+
+[BASIC]
+class-rgx=[A-Z_][a-zA-Z0-9]{2,45}
+module-rgx=.*
+const-rgx=.*
+function-rgx=.*
+method-rgx=.*
+attr-rgx=.*
+argument-rgx=.*
+variable-rgx=.*
+inlinevar-rgx=.*
 
 [SIMILARITIES]
 ignore-comments=yes

--- a/travis/test_flake8
+++ b/travis/test_flake8
@@ -6,4 +6,11 @@ flake8 . --config=${FLAKE8_CONFIG_DIR}/travis_run_flake8__init__.cfg
 status1=$?
 flake8 . --config=${FLAKE8_CONFIG_DIR}/travis_run_flake8.cfg
 status2=$?
-exit $((${status1} || ${status2}))
+
+if [[ "${status1}${status2}" == "00" ]]; then
+  echo "Flake8 OK"
+  exit 0
+else
+  echo "Flake8 ERRORS"
+  exit 1
+fi

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -17,7 +17,13 @@ fi
 IFS="/" read -a REPO <<< "${ODOO_REPO}"
 export PATH=${PATH}:${PWD}/../${REPO[1]}-${VERSION}/openerp
 
+if [[ "${VERSION}" == 6.* ]] || [[ "${VERSION}" == 7.* ]] ; then
+    # snake_case and CamelCase allow it for old version
+    export CLASS_CASE='--class-rgx=([a-z_][a-z0-9_]{2,45})|([A-Z_][a-zA-Z0-9]{2,45})$'
+fi
+
+
 #run pylint command
-pylint --rcfile=${PYLINT_CONFIG_DIR}/travis_run_pylint.cfg ${MODULES_TO_TEST}
+pylint --rcfile=${PYLINT_CONFIG_DIR}/travis_run_pylint.cfg ${CLASS_CASE} ${MODULES_TO_TEST}
 pylint_status=$?
 exit $((${pylint_status}))

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -22,8 +22,13 @@ if [[ "${VERSION}" == 6.* ]] || [[ "${VERSION}" == 7.* ]] ; then
     export CLASS_CASE='--class-rgx=([a-z_][a-z0-9_]{2,45})|([A-Z_][a-zA-Z0-9]{2,45})$'
 fi
 
-
 #run pylint command
 pylint --rcfile=${PYLINT_CONFIG_DIR}/travis_run_pylint.cfg ${CLASS_CASE} ${MODULES_TO_TEST}
 pylint_status=$?
-exit $((${pylint_status}))
+if [[ "$pylint_status" == "0" ]]; then
+  echo "Pylint OK"
+  exit 0
+else
+  echo "Pylint ERRORS"
+  exit 1
+fi

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -213,7 +213,6 @@ def main(argv=None):
     odoo_include = os.environ.get("INCLUDE")
     options = os.environ.get("OPTIONS", "").split()
     install_options = os.environ.get("INSTALL_OPTIONS", "").split()
-    expected_errors = int(os.environ.get("SERVER_EXPECTED_ERRORS", "0"))
     odoo_version = os.environ.get("VERSION")
     if not odoo_version:
         # For backward compatibility, take version from parameter
@@ -329,14 +328,7 @@ def main(argv=None):
             print(fail_msg, to_test)
         else:
             print(success_msg, to_test)
-    if expected_errors and counted_errors != expected_errors:
-        print("Expected %d errors, found %d!"
-              % (expected_errors, counted_errors))
-        return 1
-    elif counted_errors != expected_errors:
-        return 1
-    # if we get here, all is OK
-    return 0
+    return counted_errors
 
 if __name__ == '__main__':
     exit(main())

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -2,11 +2,6 @@
 
 pip install -q QUnitSuite flake8 coveralls pylint > /dev/null 2>&1
 
-# We can exit here and do nothing if this only a LINT check
-if [ "${LINT_CHECK}" == "1" ] ; then
-    exit 0
-fi
-
 # For backward compatibility, take version from parameter if it's not globally set
 if [ "x${VERSION}" == "x" ] ; then
     VERSION="${1}"

--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -44,6 +44,13 @@ def main(test_list):
         outcome = fail_msg if error else success_msg
         print("| {0:<28}{1}".format(test[0], outcome))
     print("+" + "="*39)
+    # Don't return error code if the errors are expected
+    expect_err = int(os.environ.get("EXPECTED_ERRORS", "0"))
+    if expect_err:
+        count_err = sum(results)
+        print("Expected %d errors, found %d!" % (expect_err, count_err))
+        if count_err == expect_err:
+            return 0
     return max(results)
 
 


### PR DESCRIPTION
Reviewers comment PR that we need to use CamelCase for 8.0 version and we have a [guideline](https://github.com/OCA/maintainer-tools/blob/master/CONTRIBUTING.md#odoo-python-class)

This PR enable this case.

Currently pylint and flake8 don't have `expected error`, I will to work in this other feature in other PR to add test of lint cases.

By now, I share next image with testcases:
![captura de pantalla 2015-08-05 a las 6 47 52 p m](https://cloud.githubusercontent.com/assets/6644187/9100598/81ac3b72-3ba2-11e5-98e5-7945ea06fc8b.png)

And I enabled this PR in .travis.yml in next change:
https://github.com/Vauxoo/rma/pull/43
(Red because this branch has snake_case class name)

FYI we have a script to auto-fix this case in py files more info [here](https://github.com/Vauxoo/pylint-conf/tree/master/autopep8_extended)

NOTE: The pylint fail named `C0103` enable validation for: **class**, module, constant, function, method, attributes, argument and variable names.
This PR just enable `class name` with regular expression CamelCase in pylint.conf file other checks use a regex `.*`
NOTE2: For old version `class-name-regex` is overwriten of pylint.conf with parameter in `test_pylint` script to allow `snake_case` too.