### PR TITLE
[REF] git: Add a link of video 'how to' in README file

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -26,5 +26,8 @@ sudo pip install pep8 --upgrade
 sudo pip install pylint --upgrade
 ```
 
+You can learn a option of how to use it with this [video](https://asciinema.org/a/24642)
+You can pause video and select a section to copy text.
+
 You can bypass these checks setting environment variable NOLINT before calling
 commit, e.g, `NOLINT=1 git commit`.


### PR DESCRIPTION
I created a video of how to configurate `git hook` in your local environment.
I can to share it in this repository.