### PR TITLE
Allow expected errors to also handle linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
   - VERSION="8.0" TESTS="1" LINT_CHECK="0"
 
   matrix:
-  - INCLUDE="broken_module" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
+  - INCLUDE="broken_module" EXPECTED_ERRORS="1"  # test errors are detected
   - EXCLUDE="broken_module" OPTIONS="--log-level=debug" INSTALL_OPTIONS="--log-level=info"
   - INCLUDE="test_module,second_module" UNIT_TEST="1"
   - VERSION="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # ODOO_REPO usage example
@@ -37,11 +37,11 @@ install:
   - cp -r ../maintainer-quality-tools/ $HOME
   - mv tests/test_repo/* ./
   - export PATH=$HOME/maintainer-quality-tools/travis:$PATH
-  - travis_install_nightly 8.0 # only used if VERSION not set in env
+  - travis_install_nightly
 
 script:
   - coverage run --append ./travis/self_tests
-  - coverage run --append ./travis/travis_run_tests 8.0  # only used if VERSION not set in env
+  - coverage run --append ./travis/travis_run_tests
 
 after_success:
   - coveralls

--- a/travis/test_flake8
+++ b/travis/test_flake8
@@ -6,4 +6,11 @@ flake8 . --config=${FLAKE8_CONFIG_DIR}/travis_run_flake8__init__.cfg
 status1=$?
 flake8 . --config=${FLAKE8_CONFIG_DIR}/travis_run_flake8.cfg
 status2=$?
-exit $((${status1} || ${status2}))
+
+if [[ "${status1}${status2}" == "00" ]]; then
+  echo "Flake8 OK"
+  exit 0
+else
+  echo "Flake8 ERRORS"
+  exit 1
+fi

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -20,4 +20,10 @@ export PATH=${PATH}:${PWD}/../${REPO[1]}-${VERSION}/openerp
 #run pylint command
 pylint --rcfile=${PYLINT_CONFIG_DIR}/travis_run_pylint.cfg ${MODULES_TO_TEST}
 pylint_status=$?
-exit $((${pylint_status}))
+if [[ "$pylint_status" == "0" ]]; then
+  echo "Pylint OK"
+  exit 0
+else
+  echo "Pylint ERRORS"
+  exit 1
+fi

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -213,7 +213,6 @@ def main(argv=None):
     odoo_include = os.environ.get("INCLUDE")
     options = os.environ.get("OPTIONS", "").split()
     install_options = os.environ.get("INSTALL_OPTIONS", "").split()
-    expected_errors = int(os.environ.get("SERVER_EXPECTED_ERRORS", "0"))
     odoo_version = os.environ.get("VERSION")
     if not odoo_version:
         # For backward compatibility, take version from parameter
@@ -329,14 +328,7 @@ def main(argv=None):
             print(fail_msg, to_test)
         else:
             print(success_msg, to_test)
-    if expected_errors and counted_errors != expected_errors:
-        print("Expected %d errors, found %d!"
-              % (expected_errors, counted_errors))
-        return 1
-    elif counted_errors != expected_errors:
-        return 1
-    # if we get here, all is OK
-    return 0
+    return counted_errors
 
 if __name__ == '__main__':
     exit(main())

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -3,7 +3,7 @@
 pip install -q QUnitSuite flake8 coveralls pylint > /dev/null 2>&1
 
 # We can exit here and do nothing if this only a LINT check
-if [ "${LINT_CHECK}" == "1" ] ; then
+if [ "${TESTS}" == "0" ] ; then
     exit 0
 fi
 

--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -44,6 +44,13 @@ def main(test_list):
         outcome = fail_msg if error else success_msg
         print("| {0:<28}{1}".format(test[0], outcome))
     print("+" + "="*39)
+    # Don't return error code if the errors are expected
+    expect_err = int(os.environ.get("EXPECTED_ERRORS", "0"))
+    if expect_err:
+        count_err = sum(results)
+        print("Expected %d errors, found %d!" % (expect_err, count_err))
+        if count_err == expect_err:
+            return 0
     return max(results)
 
 


### PR DESCRIPTION
Expected error check is moved from server tests to the test controller `travis_run_tests`.
This allows to expect for types of errors other than server errors, such as lint errors.

Extracted from the PR #223  