### PR TITLE
[IMP] run_pylint: Add feature to check new conventions just in modules changed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ env:
   - INCLUDE="test_module,second_module" UNIT_TEST="1"
   - VERSION="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # ODOO_REPO usage example
   - VERSION="6.1" INCLUDE="test_module,second_module"
-  - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="17"
+  - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="17" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
+  - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="18" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
 
 install:
   - cp -r ../maintainer-quality-tools/ $HOME

--- a/travis/cfg/travis_run_pylint_pr.cfg
+++ b/travis/cfg/travis_run_pylint_pr.cfg
@@ -1,0 +1,33 @@
+[MASTER]
+profile=no
+ignore=CVS,.git,scenarios,.bzr,__openerp__.py,__odoo__.py,__terp__.py
+persistent=yes
+cache-size=500
+
+[MESSAGES CONTROL]
+disable=all
+# This change don't add new checks.
+# Adding one exits check to test the pr-diff feature
+enable=W0403
+
+[REPORTS]
+msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
+output-format=colorized
+files-output=no
+reports=no
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+comment=no
+
+[FORMAT]
+indent-string='    '
+
+[SIMILARITIES]
+ignore-comments=yes
+ignore-docstrings=yes
+
+[MISCELLANEOUS]
+notes=
+
+[IMPORTS]
+deprecated-modules=pdb,pudb,ipdb
+

--- a/travis/getaddons.py
+++ b/travis/getaddons.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 import os
 import sys
 
+from git_run import GitRun
 
 MANIFEST_FILES = ['__odoo__.py', '__openerp__.py', '__terp__.py']
 
@@ -54,6 +55,28 @@ def get_addons(path):
                for x in os.listdir(path)
                if is_addons(os.path.join(path, x))]
     return res
+
+
+def get_modules_changed(path, ref='HEAD'):
+    '''Get modules changed from git diff-index {ref}
+    :param path: String path of git repo
+    :param ref: branch or remote/branch or sha to compare
+    :return: List of paths of modules changed
+    '''
+    git_run_obj = GitRun(os.path.join(path, '.git'))
+    git_run_obj.run(['fetch'] + ref.split('/'))
+    items_changed = git_run_obj.get_items_changed(ref)
+    folders_changed = set([
+        item_changed.split('/')[0]
+        for item_changed in items_changed
+        if '/' in item_changed]
+    )
+    modules = set(get_modules(path))
+    modules_changed = list(modules & folders_changed)
+    modules_changed_path = [
+        os.path.join(path, module_changed)
+        for module_changed in modules_changed]
+    return modules_changed_path
 
 
 def main(argv=None):

--- a/travis/git_run.py
+++ b/travis/git_run.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+import subprocess
+
+
+class GitRun(object):
+    def __init__(self, repo_path):
+        self.repo_path = repo_path
+
+    def run(self, command):
+        """Execute git command in bash
+        :param list command: Git cmd to execute in self.repo_path
+        :return: String output of command executed.
+        """
+        cmd = ['git', '--git-dir=' + self.repo_path] + command
+        try:
+            res = subprocess.check_output(cmd)
+        except subprocess.CalledProcessError:
+            res = None
+        if isinstance(res, basestring):
+            res = res.strip('\n')
+        return res
+
+    def get_items_changed(self, base_ref='HEAD'):
+        """Get name of items changed in self.repo_path
+        This is a wrapper method of git command:
+            git diff-index --name-only --cached {base_ref}
+        :param base_ref: String of branch or sha base.
+            e.g. "master" or "SHA_NUMBER"
+        :return: List of name of items changed
+        """
+        command = ['diff-index', '--name-only',
+                   '--cached', base_ref]
+        res = self.run(command)
+        items = res.split('\n') if res else []
+        return items

--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -98,4 +98,8 @@ def main(paths, config_file, sys_paths=None, extra_params=None):
 
 
 if __name__ == '__main__':
-    exit(main(standalone_mode=False))
+    try:
+        exit(main(standalone_mode=False))
+    except click.ClickException as e:
+        e.show()
+        exit(e.exit_code)

--- a/travis/self_tests
+++ b/travis/self_tests
@@ -53,3 +53,6 @@ if os.environ.get('LINT_CHECK', 0) == '1':
         "--config-file=" + pylint_rcfile,
         "--path", empty_path], standalone_mode=False)
     assert -1 == count_errors
+
+# Testing git run from getaddons
+getaddons.get_modules_changed(repo_dir)

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -10,6 +10,7 @@ import os
 import run_pylint
 import travis_helpers
 
+from getaddons import get_modules_changed
 
 pylint_rcfile = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
@@ -18,6 +19,33 @@ pylint_rcfile = os.path.join(
 count_errors = run_pylint.main([
     "--config-file=" + pylint_rcfile,
 ], standalone_mode=False)
+
+
+pylint_rcfile_pr = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    'cfg',
+    "travis_run_pylint_pr.cfg")
+
+is_pull_request = os.environ.get(
+    'TRAVIS_PULL_REQUEST', 'false') != 'false'
+branch_base = os.environ.get('TRAVIS_BRANCH', False)
+git_work_dir = os.environ.get('TRAVIS_BUILD_DIR', False)
+if is_pull_request and branch_base and git_work_dir:
+    modules_changed = get_modules_changed(
+        git_work_dir,
+        'origin/' + branch_base)
+    modules_changed_cmd = []
+    for module_changed in modules_changed:
+        modules_changed_cmd.extend([
+            '--path',
+            module_changed,
+        ])
+    count_errors += run_pylint.main([
+        "--config-file=" + pylint_rcfile_pr,
+    ] + modules_changed_cmd, standalone_mode=False)
+else:
+    # TODO: Add git hook case in other PR
+    pass
 
 expected_errors = int(
     os.environ.get('PYLINT_EXPECTED_ERRORS', 0))


### PR DESCRIPTION
Currently, we have a problem that if we add a new conventions in pylint-test-1 we will have all repos red in travis builds for stable branches and PR ones.

But currently we are working with next steps:
 1. We have created a new pr to oca/PROJECT-X branch 8.0
 2. We received feedabck from reviewers:
   3. Please, rename the class to `CamelCase`
   4. Please, add OCA author.
   5. Please, change your comment `encondig` by `coding`
   6. Other ones.

If we can automate it, Why not automate it?
Save time of reviewer, save time of developers just in new changes.

Then we need a middle step to add new conventions without have all repos red.
We can change the modules progressively of new conventions.

This feature run with original
`pylint pylint.cfg all_modules`
plus run other one with new conventions in just modified modules
`pylint pylint_PR.cfg modified_modules`

New conventions by example

 - CamelCase

We don't need wait to fix all repositories in all base branches to add this new convention.
We can add new conventions and check it just in new changes.
After a consider time we can move new conventions to old conventions.

![travis_feature](https://cloud.githubusercontent.com/assets/6644187/9338522/c3073c18-45aa-11e5-8533-29cc0f61299a.png)

Notice in `TRAVIS_PULL_REQUEST='true'` case the erros are old_conventions + new_conventions.

The old conventions are active in all modules in PR cases.

Why `TRAVIS_PULL_REQUEST="true"` and `TRAVIS_BRANCH`?
We don't have control on travis app :(
TRAVIS_PULL_REQUEST is a [environment variable of travis](http://docs.travis-ci.com/user/environment-variables/#Convenience-Variables)
![environment variables - travis ci 2015-08-21 09-41-33](https://cloud.githubusercontent.com/assets/6644187/9410958/d3e63378-47e8-11e5-85ce-b64515c24c43.png)
This is needed here because we need to know if [is_pull_request](https://github.com/OCA/maintainer-quality-tools/blob/87f2b269667c02af210493e929eb9524eb455907/travis/travis_run_tests#L57-L58) (Currently we have this code in stable branch) to verify new conventions just in PR cases to detect a diff with base branch `TRAVIS_BRANCH`.
![environment variables - travis ci 2015-08-21 09-43-57](https://cloud.githubusercontent.com/assets/6644187/9411021/29e8fea4-47e9-11e5-82e1-25269c279a18.png)

Now we can get git diff of `TRAVIS_BUILD_DIR`
![environment variables - travis ci 2015-08-21 09-45-24](https://cloud.githubusercontent.com/assets/6644187/9411044/5d114688-47e9-11e5-8036-a53b2d53e20d.png)

With next command if is PR:
```python
  git --git_dir=${TRAVIS_BUILD_DIR}/.git diff-index origin/${TRAVIS_BRANCH}
```
Now, we have all items changed in a PR...
