### PR TITLE
[REF] pylint: Change number of message by name of message and add multiline

### DIFF
--- a/travis/cfg/travis_run_pylint.cfg
+++ b/travis/cfg/travis_run_pylint.cfg
@@ -6,6 +6,24 @@ cache-size=500
 
 [MESSAGES CONTROL]
 disable=all
+
+# Enable message and code:
+#   anomalous-backslash-in-string - W1401
+#   assignment-from-none - W1111
+#   dangerous-default-value - W0102
+#   deprecated-module - W0402
+#   duplicate-key - W0109
+#   file-ignored - I0013
+#   pointless-statement - W0104
+#   pointless-string-statement - W0105
+#   print-statement - E1601
+#   redundant-keyword-arg - E1124
+#   reimported - W0404
+#   relative-import - W0403
+#   return-in-init - E0101
+#   too-few-format-args - E1306
+#   unreachable - W0101
+
 enable=anomalous-backslash-in-string,
     assignment-from-none,
     dangerous-default-value,

--- a/travis/cfg/travis_run_pylint.cfg
+++ b/travis/cfg/travis_run_pylint.cfg
@@ -6,7 +6,21 @@ cache-size=500
 
 [MESSAGES CONTROL]
 disable=all
-enable=E0101,E1124,E1306,E1601,I0013,W0101,W0102,W0104,W0105,W0109,W0403,W0404,W1111,W1401,W0402
+enable=anomalous-backslash-in-string,
+    assignment-from-none,
+    dangerous-default-value,
+    deprecated-module,
+    duplicate-key,
+    file-ignored,
+    pointless-statement,
+    pointless-string-statement,
+    print-statement,
+    redundant-keyword-arg,
+    reimported,
+    relative-import,
+    return-in-init,
+    too-few-format-args,
+    unreachable,
 
 [REPORTS]
 msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}


### PR DESCRIPTION
* Numbers2name
 Many times we need to check the pylint official documentation to get pylint-number information.
 But if we use the message-short-name is easiest identify it.
 By example:
  - `duplicated-key` is more explicit that `W0109`

* Multi-lines
 - To reduce conflicts of use same line if add new or remove old checks.
 - To identify a PR diff easiest.