### PR TITLE
[ADD] gen_addons_table script

### DIFF
--- a/sample_files/README.md
+++ b/sample_files/README.md
@@ -5,8 +5,11 @@
 
 # ${REPO_NAME_VERBOSE}
 
-${REPO_DESCRIPTION_AND_MODULE_LIST}
+${REPO_DESCRIPTION}
 
+[//]: # (addons)
+This part will be replaced when running the gen_addon_tables script.
+[//]: # (end addons)
 
 Translation Status
 ------------------

--- a/travis/gen_addons_table
+++ b/travis/gen_addons_table
@@ -1,4 +1,4 @@
-#!/usr/env/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 import ast
 import os

--- a/travis/gen_addons_table
+++ b/travis/gen_addons_table
@@ -1,4 +1,21 @@
 #!/usr/bin/env python
+#  -*- coding: utf-8 -*-
+"""
+This script replaces markers in the README.md files
+of an OCA repository with the list of addons present
+in the repository. It preserves the marker so it
+can be run again.
+
+The script must be run from the root of the repository,
+where the README.md file can be found.
+
+Markers in README.md must have the form:
+
+[//]: # (addons)
+does not matter, will be replaced by the script
+[//]: # (end addons)
+"""
+
 from __future__ import print_function
 import ast
 import os

--- a/travis/gen_addons_table
+++ b/travis/gen_addons_table
@@ -83,7 +83,11 @@ def gen_addons_table():
             version = manifest.get('version') or ''
             summary = manifest.get('summary') or manifest.get('name')
             summary = sanitize_cell(summary)
-            if not unported and manifest.get('installable', True):
+            installable = manifest.get('installable', True)
+            if unported and installable:
+                raise UserError('%s is in __unported__ but is marked '
+                                'installable.' % addon_path)
+            if installable:
                 rows_available.append((link, version, summary))
             else:
                 rows_unported.append((link, version + ' (unported)', summary))

--- a/travis/gen_addons_table.py
+++ b/travis/gen_addons_table.py
@@ -1,0 +1,99 @@
+#!/usr/env/bin/python
+from __future__ import print_function
+import ast
+import os
+import re
+
+
+MARKERS = r'(\[//\]: # \(addons\))|(\[//\]: # \(end addons\))'
+
+
+class UserError(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+
+def sanitize_cell(s):
+    if not s:
+        return ''
+    s = ' '.join(s.split())
+    return s
+
+
+def render_markdown_table(header, rows):
+    table = []
+    rows = [header, ['---'] * len(header)] + rows
+    for row in rows:
+        table.append(' | '.join(row))
+    return '\n'.join(table)
+
+
+def replace_in_readme(readme_path, header, rows_available, rows_unported):
+    readme = open(readme_path).read()
+    parts = re.split(MARKERS, readme, flags=re.MULTILINE)
+    if len(parts) != 7:
+        raise UserError('Addons markers not found or incorrect in %s' %
+                        readme_path)
+    addons = []
+    if rows_available:
+        addons.extend([
+            '\n',
+            'Available addons\n',
+            '----------------\n',
+            render_markdown_table(header, rows_available),
+            '\n'
+        ])
+    if rows_unported:
+        addons.extend([
+            '\n',
+            'Unported addons\n',
+            '---------------\n',
+            render_markdown_table(header, rows_unported),
+            '\n'
+        ])
+    parts[2:5] = addons
+    readme = ''.join(parts)
+    open(readme_path, 'w').write(readme)
+
+
+def gen_addons_table():
+    readme_path = 'README.md'
+    if not os.path.isfile(readme_path):
+        raise UserError('%s not found' % readme_path)
+    # list addons in . and __unported__
+    addon_paths = []  # list of (addon_path, unported)
+    for addon_path in os.listdir('.'):
+        addon_paths.append((addon_path, False))
+    unported_directory = '__unported__'
+    if os.path.isdir(unported_directory):
+        for addon_path in os.listdir(unported_directory):
+            addon_path = os.path.join(unported_directory, addon_path)
+            addon_paths.append((addon_path, True))
+    addon_paths = sorted(addon_paths, lambda x, y: cmp(x[0], y[0]))
+    # load manifests
+    header = ('addon', 'version', 'summary')
+    rows_available = []
+    rows_unported = []
+    for addon_path, unported in addon_paths:
+        manifest_path = os.path.join(addon_path, '__openerp__.py')
+        if os.path.isfile(manifest_path):
+            manifest = ast.literal_eval(open(manifest_path).read())
+            addon_name = os.path.basename(addon_path)
+            link = '[%s](%s/)' % (addon_name, addon_path)
+            version = manifest.get('version') or ''
+            summary = manifest.get('summary') or manifest.get('name')
+            summary = sanitize_cell(summary)
+            if not unported and manifest.get('installable', True):
+                rows_available.append((link, version, summary))
+            else:
+                rows_unported.append((link, version + ' (unported)', summary))
+    # replace table in README.md
+    replace_in_readme(readme_path, header, rows_available, rows_unported)
+
+
+if __name__ == '__main__':
+    try:
+        gen_addons_table()
+    except UserError as e:
+        print(e.msg)
+        exit(1)


### PR DESCRIPTION
A script that replaces a placeholder in the repository-level README.md with two tables showing the available and unported modules along with their version number and a summary (or name if summary is absent). The placeholder is preserved after running the script.

The placeholder in README.md must be like this (```...``` can be anything):
```
[//]: # (addons)
...
[//]: # (end addons)
```

The (weird) syntax for markdown comments comes from http://stackoverflow.com/questions/4823468/store-comments-in-markdown-syntax.

TODO
* [ ] insert the placeholder in all repos README.md (I volonteer to do that)
* [ ] automate the regeneration (in travis_after_success or a bot, help welcome)
