### PR TITLE
[REF] test_pylint: Show warning of empty paths but no error. Add colors to pylint global result.

### DIFF
--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -8,6 +8,7 @@ Script to process pylint run and exit with result.
 import os
 
 import run_pylint
+import travis_helpers
 
 
 pylint_rcfile = os.path.join(
@@ -22,11 +23,13 @@ expected_errors = int(
     os.environ.get('PYLINT_EXPECTED_ERRORS', 0))
 
 exit_status = 0
-if count_errors != expected_errors:
-    print("pylint expected errors {expected_errors}, "
+if count_errors == -1:
+    print(travis_helpers.yellow('Python modules not found'))
+elif count_errors != expected_errors:
+    print(travis_helpers.red("pylint expected errors {expected_errors}, "
           "found {number_errors}!".format(
               expected_errors=expected_errors,
-              number_errors=count_errors))
+              number_errors=count_errors)))
     exit_status = 1
 
 exit(exit_status)


### PR DESCRIPTION
Change from this
![captura de pantalla 2015-08-31 a las 1 41 39 p m](https://cloud.githubusercontent.com/assets/6644187/9587059/0a8e8722-4fe6-11e5-8d82-11664a06f088.png)

to this
<img width="572" alt="captura de pantalla 2015-08-31 a las 1 40 46 p m" src="https://cloud.githubusercontent.com/assets/6644187/9587039/f1b6794e-4fe5-11e5-8e35-50b10adb4d30.png">

And add red message in error case.