### PR TITLE
[IMP] pylint: Enable check of cyclomatic complexity

### DIFF
--- a/travis/cfg/travis_run_pylint_pr.cfg
+++ b/travis/cfg/travis_run_pylint_pr.cfg
@@ -27,6 +27,7 @@ disable=all
 #   no-utf8-coding-comment - C8201
 #   openerp-exception-warning - R8101
 #   rst-syntax-error - E7901
+#   too-complex - C0901
 #   translation-field - W8103
 #   use-vim-comment - W8202
     
@@ -43,6 +44,7 @@ enable=api-one-multi-together,
     no-utf8-coding-comment,
     openerp-exception-warning,
     rst-syntax-error,
+    too-complex,
     translation-field,
     use-vim-comment,
 

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pip install -q QUnitSuite flake8 coveralls Click oca-pylint-plugin > /dev/null 2>&1
+pip install -q QUnitSuite flake8 coveralls Click oca-pylint-plugin pylint-mccabe > /dev/null 2>&1
 
 # We can exit here and do nothing if this only a LINT check
 if [ "${LINT_CHECK}" == "1" ] ; then


### PR DESCRIPTION
We have next [guideline](https://github.com/OCA/maintainer-tools/blob/master/CONTRIBUTING.md#idioms):
`If a function is too long or too indented due to loops, this is a sign that it needs to be refactored into smaller functions`

The unit of measure of [cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) can to help us to check it

Before of enable this check I need to know if is a good idea for you.