### PR TITLE
[IMP] pylint: Enable check to verify fields with _('string')

### DIFF
--- a/tests/test_repo/broken_lint/__init__.py
+++ b/tests/test_repo/broken_lint/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import case_import
+from . import case_fields

--- a/tests/test_repo/broken_lint/case_fields.py
+++ b/tests/test_repo/broken_lint/case_fields.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+
+from openerp import fields, models
+from openerp.tools.translate import _
+
+
+class MyExampleField(models.Model):
+    _name = "my.example.field"
+    _columns = {
+        'name': fields.char(_('Title'), 100),
+        'description': fields.char(string=_('Description'), size=100),
+    }
+
+
+class MyExampleField2(models.Model):
+    _name = "my.example.field2"
+
+    name = fields.Char(_('Title'), 100)
+    description = fields.Char(name=_('Description'), size=100)
+
+    def my_method1(self, var):
+        pass
+
+    def my_method2(self):
+        return self.my_method1(_('Hello world'))

--- a/travis/cfg/travis_run_pylint_pr.cfg
+++ b/travis/cfg/travis_run_pylint_pr.cfg
@@ -27,6 +27,7 @@ disable=all
 #   no-utf8-coding-comment - C8201
 #   openerp-exception-warning - R8101
 #   rst-syntax-error - E7901
+#   translation-field - W8103
 #   use-vim-comment - W8202
     
 enable=api-one-multi-together,
@@ -42,6 +43,7 @@ enable=api-one-multi-together,
     no-utf8-coding-comment,
     openerp-exception-warning,
     rst-syntax-error,
+    translation-field,
     use-vim-comment,
 
 [REPORTS]


### PR DESCRIPTION
[example](https://github.com/OCA/sale-workflow/pull/213#discussion_r39856737)

Result of this PR:
```log
************* Module broken_lint.case_fields
broken_lint/case_fields.py:10: [W8103(translation-field), MyExampleField] Translation method _("string") in fields is not necessary.
broken_lint/case_fields.py:11: [W8103(translation-field), MyExampleField] Translation method _("string") in fields is not necessary.
broken_lint/case_fields.py:18: [W8103(translation-field), MyExampleField2] Translation method _("string") in fields is not necessary.
broken_lint/case_fields.py:19: [W8103(translation-field), MyExampleField2] Translation method _("string") in fields is not necessary.
```
![translation-field](https://cloud.githubusercontent.com/assets/6644187/10029165/1b3146da-6136-11e5-8dba-3fa241322e0a.png)

