### PR TITLE
[REF] after_success: Show coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ script:
   - coverage run --append ./travis/travis_run_tests 8.0  # only used if VERSION not set in env
 
 after_success:
-  - travis_after_tests_success
+  - TESTS="1" LINT_CHECK="0" travis_after_tests_success

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ script:
   - coverage run --append ./travis/travis_run_tests 8.0  # only used if VERSION not set in env
 
 after_success:
-  - coveralls
+  - travis_after_tests_success

--- a/travis/travis_after_tests_success
+++ b/travis/travis_after_tests_success
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 
 import os
+
+from coverage.cmdline import main as coverage_main
 from coveralls import cli as coveralls_cli
 
 if (os.environ.get('TESTS', '1') == '1' and
         not os.environ.get('LINT_CHECK') == '1'):
+    coverage_main(["report", "--show-missing"])
     exit(coveralls_cli.main(argv=None))


### PR DESCRIPTION
If coveralls.io [fails](https://github.com/OCA/maintainer-quality-tools/issues/247)
we have a emergency option: show a small report in log output.

Example
![example](https://cloud.githubusercontent.com/assets/6644187/10006729/65b77d02-6085-11e5-8261-e7ecb0fd97e0.png)