### PR TITLE
[REF] .travis.yml: Fix caching of travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@
 # Instead use the files under the "/sample_files" directory for that purpose.
 language: python
 sudo: false
-cache: pip
+cache:
+  apt: true
+  directories:
+    - $HOME/.cache/pip
 
 python:
   - "2.7"

--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 sudo: false
-cache: pip
+cache:
+  apt: true
+  directories:
+    - $HOME/.cache/pip
 
 python:
   - "2.7"
@@ -10,12 +13,16 @@ addons:
 # only add the two lines below if you need wkhtmltopdf for your tests
 #    sources:
 #      - pov-wkhtmltopdf
+#    Search your sources alias here:
+#      https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml  # because pip installation is slow
       - python-simplejson
       - python-serial
       - python-yaml
+#     Search your packages here:
+#       https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
 #      - wkhtmltopdf  # only add if needed and check the before_install section below
 
 # set up an X server to run wkhtmltopdf.


### PR DESCRIPTION
Currently we have a error in cache result
[could not download cache](https://travis-ci.org/OCA/maintainer-quality-tools/jobs/81485157#L136)
![downloading](https://cloud.githubusercontent.com/assets/6644187/10012084/8515b012-60c9-11e5-8c6c-766adf7482db.png)

[Store cache - empty file](https://travis-ci.org/OCA/maintainer-quality-tools/jobs/81485157#L281)
![storing](https://cloud.githubusercontent.com/assets/6644187/10012086/899c3fca-60c9-11e5-9bc1-98931a934ca7.png)

With this PR we will have in `store cache` next output:
```bash
store build cache
3.54schange detected:
/home/travis/.cache/pip/http/0/8/c/d/4/08cd447a8124a068fe40c29b184ad1eca9cda6eff048ab59ffbaab5e
/home/travis/.cache/pip/http/0/c/7/8/c/0c78cc5ddccddcf3238359feeac7e1cddd59216d6ded4659cf5965cd
/home/travis/.cache/pip/http/0/e/5/0/b/0e50bf69d3ad563fafdaccae0f81317c29bda91e335305bd70fbb8e3
/home/travis/.cache/pip/http/0/e/7/b/9/0e7b99547a0247a24df2175f35e166cf96f0194417e99b4851dbf306
/home/travis/.cache/pip/http/0/e/b/8/e/0eb8e3da6d73f4de2940eb7f94eb65bff81ab4540a1ff6e224e1b0f5
/home/travis/.cache/pip/http/0/f/f/a/6/0ffa60b4c6d3f16553f8ef8c4af3f6a5d90eaf3bdd53e6fb6b68b18d
/home/travis/.cache/pip/http/1/0/2/d/9/102d9c94cb89db710e6029edf47c1d7585244150d5aff52a977a6db4
/home/travis/.cache/pip/http/1/0/a/6/2/10a620e0856d288f49b352905b2e4ec074bbe2d03add40e9badb0573
/home/travis/.cache/pip/http/1/1/e/6/3/11e6352ce47b916e90cf69f055c0be9649d391395dcb34c6401fd1bd
/home/travis/.cache/pip/http/1/3/b/b/e/13bbe3235c2b43d1debb8e312939afb0d36cdab76dfee360c822af58
/home/travis/.cache/pip/http/1/4/6/2/8/14
changes detected, packing new archive
uploading archive
```
![cache-stored](https://cloud.githubusercontent.com/assets/6644187/10028297/36f7439c-6131-11e5-89f9-ced4a0b9353f.png)

