### PR TITLE
[FIX] let travis tools ignore uninstallable modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
 
   matrix:
   - INCLUDE="broken_module" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
-  - EXCLUDE="broken_module" OPTIONS="--log-level=debug" INSTALL_OPTIONS="--log-level=info"
+  - EXCLUDE="broken_module,broken_lint" OPTIONS="--log-level=debug" INSTALL_OPTIONS="--log-level=info"
   - INCLUDE="test_module,second_module" UNIT_TEST="1"
   - VERSION="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # ODOO_REPO usage example
   - VERSION="6.1" INCLUDE="test_module,second_module"

--- a/tests/test_repo/broken_lint/__openerp__.py
+++ b/tests/test_repo/broken_lint/__openerp__.py
@@ -7,5 +7,5 @@
     'depends': [],
     'data': [],
     'test': [],
-    'installable': False,
+    'installable': True,
 }

--- a/tests/test_repo/broken_uninstallable/I0013.py
+++ b/tests/test_repo/broken_uninstallable/I0013.py
@@ -1,0 +1,1 @@
+# pylint: skip-file

--- a/tests/test_repo/broken_uninstallable/README.rst
+++ b/tests/test_repo/broken_uninstallable/README.rst
@@ -1,0 +1,4 @@
+Module broken installable = False
+===================================
+``````````
+syntax error

--- a/tests/test_repo/broken_uninstallable/__init__.py
+++ b/tests/test_repo/broken_uninstallable/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/python
+# -*- coding: latin-1 -*-
+from . import model
+from . import interpreter_wox
+# execution permission and interpreter done

--- a/tests/test_repo/broken_uninstallable/__openerp__.py
+++ b/tests/test_repo/broken_uninstallable/__openerp__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Broken uninstallable module for tests',
+    # missing license
+    'author': 'Many People',  # Missing oca author
+    'description': 'Should be a README.rst file',
+    'version': '1.0',
+    'depends': ['base'],
+    'data': ['model_view.xml'],
+    'test': ['test.yml'],
+    'installable': False,
+    'name': 'Duplicated value',
+    'active': True,  # Deprecated active key
+}

--- a/tests/test_repo/broken_uninstallable/doc/index.rst
+++ b/tests/test_repo/broken_uninstallable/doc/index.rst
@@ -1,0 +1,4 @@
+Module broken
+===============
+``````````
+syntax error

--- a/tests/test_repo/broken_uninstallable/interpreter_wox.py
+++ b/tests/test_repo/broken_uninstallable/interpreter_wox.py
@@ -1,0 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+
+"Module python with interpreter but without execute permission."

--- a/tests/test_repo/broken_uninstallable/model.py
+++ b/tests/test_repo/broken_uninstallable/model.py
@@ -1,0 +1,69 @@
+# missing coding
+from openerp.osv import orm, fields
+
+import os
+import os as os2  # W0404 - duplicated import
+
+import __openerp__  # W0403 - relative import
+
+
+class test_model(orm.Model):
+    _name = "test.model"
+    _columns = {
+        'name': fields.char('Title', 100),
+    }
+
+    def method_test(self, arg1, arg2):
+        return None
+
+    def method_e1124(self):
+        value = self.method_test(
+            'arg_param1', arg1='arg_param1')
+        return value
+
+    def method_e1306(self):
+        return "%s %s" % ('value1')
+
+    def method_e1601(self):
+        print "Hello world!"
+
+    def method_w0101(self):
+        return True
+        return False
+
+    def method_w0102(self, arg1, arg2=[]):
+        # avoid imported but unused
+        all_imports = (
+            os, os2, __openerp__)
+        return all_imports
+
+    def method_w0104_w0105(self):
+        2*6*0
+        "str any effect"
+
+    def method_w0109(self):
+        my_duplicated_key_dict = {
+            'key1': 'value1',
+            'key2': 'value2',
+            'key1': 'value3',
+        }
+        return my_duplicated_key_dict
+
+    def method_w1401(self):
+        my_regex_str_bad = '\d'
+        my_regex_str_good = r'\d'
+        return my_regex_str_bad, my_regex_str_good
+
+
+if __name__ == '__main__':
+
+    def method_w1111():
+        return None
+
+    VAR1 = method_w1111()
+
+    class E0101(object):
+        def __init__(self):
+            return 'E0101'
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/tests/test_repo/broken_uninstallable/model_view.xml
+++ b/tests/test_repo/broken_uninstallable/model_view.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_model_form" model="ir.ui.view">
+            <field name="name">view.model.form</field>
+            <field name="model">test.model</field>
+            <field name="arch" type="xml">
+                <form string="Test model">
+                    <field name="name"/>
+                </form>
+            </field>
+        </record>
+        <!-- duplicate record id-->
+        <record id="view_model_form" model="ir.ui.view">
+            <field name="name">view.model.form</field>
+            <field name="model">test.model</field>
+            <field name="arch" type="xml">
+                <tree string="Test model">
+                    <field name="name"/>
+                </tree>
+            </field>
+        </record>
+
+        <!--ir.filters without explicit user_id-->
+        <record id="filter_test_model" model="ir.filters">
+            <field name="name">By name</field>
+            <field name="model_id">test.model</field>
+            <field name="context">{'group_by': ['name']}</field>
+        </record>
+
+    </data>
+</openerp>

--- a/tests/test_repo/broken_uninstallable/test.yml
+++ b/tests/test_repo/broken_uninstallable/test.yml
@@ -1,0 +1,5 @@
+-
+  Inject a test error
+-
+  !assert {model: res.users, id: base.user_demo, string: Generated failure}:
+    - False

--- a/tests/test_repo/broken_uninstallable/tests/__init__.py
+++ b/tests/test_repo/broken_uninstallable/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import dummy_test

--- a/tests/test_repo/broken_uninstallable/tests/dummy_test.py
+++ b/tests/test_repo/broken_uninstallable/tests/dummy_test.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# missing coding
+"""This file is not added to main __init__
+We need to validate that check py errors"""
+
+try:
+    from openerp.exceptions import Warning
+except ImportError:
+    pass
+
+
+def using_imported():
+    return Warning

--- a/travis/getaddons.py
+++ b/travis/getaddons.py
@@ -6,6 +6,7 @@ With -m flag, will return a list of modules names instead.
 """
 
 from __future__ import print_function
+import ast
 import os
 import sys
 
@@ -15,18 +16,20 @@ MANIFEST_FILES = ['__odoo__.py', '__openerp__.py', '__terp__.py']
 
 
 def is_module(path):
-    """return False if the path doesn't contain an odoo module, and the full
-    path to the module manifest otherwise"""
+    """return False if the path doesn't contain an installable odoo module,
+    and the full path to the module manifest otherwise"""
 
     if not os.path.isdir(path):
         return False
     files = os.listdir(path)
     filtered = [x for x in files if x in (MANIFEST_FILES + ['__init__.py'])]
     if len(filtered) == 2 and '__init__.py' in filtered:
-        return os.path.join(
+        manifest_path = os.path.join(
             path, next(x for x in filtered if x != '__init__.py'))
-    else:
-        return False
+        manifest = ast.literal_eval(open(manifest_path).read())
+        if manifest.get('installable', True):
+            return manifest_path
+    return False
 
 
 def get_modules(path):

--- a/travis/getaddons.py
+++ b/travis/getaddons.py
@@ -16,16 +16,25 @@ MANIFEST_FILES = ['__odoo__.py', '__openerp__.py', '__terp__.py']
 
 
 def is_module(path):
-    """return False if the path doesn't contain an installable odoo module,
-    and the full path to the module manifest otherwise"""
+    """return False if the path doesn't contain an odoo module, and the full
+    path to the module manifest otherwise"""
 
     if not os.path.isdir(path):
         return False
     files = os.listdir(path)
     filtered = [x for x in files if x in (MANIFEST_FILES + ['__init__.py'])]
     if len(filtered) == 2 and '__init__.py' in filtered:
-        manifest_path = os.path.join(
+        return os.path.join(
             path, next(x for x in filtered if x != '__init__.py'))
+    else:
+        return False
+
+
+def is_installable_module(path):
+    """return False if the path doesn't contain an installable odoo module,
+    and the full path to the module manifest otherwise"""
+    manifest_path = is_module(path)
+    if manifest_path:
         manifest = ast.literal_eval(open(manifest_path).read())
         if manifest.get('installable', True):
             return manifest_path
@@ -41,7 +50,7 @@ def get_modules(path):
     res = []
     if os.path.isdir(path) and not os.path.basename(path)[0] == '.':
         res = [x for x in os.listdir(path)
-               if is_module(os.path.join(path, x))]
+               if is_installable_module(os.path.join(path, x))]
     return res
 
 

--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -9,6 +9,8 @@ import sys
 import click
 import pylint.lint
 
+import getaddons
+
 CLICK_DIR = click.Path(exists=True, dir_okay=True, resolve_path=True)
 
 
@@ -38,9 +40,13 @@ def get_subpaths(paths):
             subpaths.extend(
                 [os.path.join(path, item)
                  for item in os.listdir(path)
-                 if os.path.isfile(os.path.join(path, item, '__init__.py'))])
+                 if os.path.isfile(os.path.join(path, item, '__init__.py')) and
+                 (not getaddons.is_module(os.path.join(path, item)) or
+                  getaddons.is_installable_module(os.path.join(path, item)))])
         else:
-            subpaths.append(path)
+            if not getaddons.is_module(path) or \
+                    getaddons.is_installable_module(path):
+                subpaths.append(path)
     return subpaths
 
 

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -6,7 +6,7 @@ import re
 import os
 import subprocess
 import sys
-from getaddons import get_addons, get_modules, is_module
+from getaddons import get_addons, get_modules, is_installable_module
 from travis_helpers import success_msg, fail_msg
 
 
@@ -165,7 +165,8 @@ def get_test_dependencies(addons_path, addons_list):
         return ['base']
     else:
         for path in addons_path.split(','):
-            manif_path = is_module(os.path.join(path, addons_list[0]))
+            manif_path = is_installable_module(
+                os.path.join(path, addons_list[0]))
             if not manif_path:
                 continue
             manif = eval(open(manif_path).read())


### PR DESCRIPTION
The following commands need to be adapted to ignore uninstallable modules
* [x] pylint

Later:
* coverage (it seems `__unported__` is not excluded from coverage at the moment, so this can be left for another PR)
* code climate (we just have a sample file, so this can be left for a future improvement)