### PR TITLE
[REF] pylint_run: Use of pylint_odoo instead of deprecated pylint_oca

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ install:
   - mv tests/test_repo/* ./
   - export PATH=$HOME/maintainer-quality-tools/travis:$PATH
   - travis_install_nightly 8.0 # only used if VERSION not set in env
+  - pip install coveralls  # Force install coveralls in all cases of MQT for self_test script.
   - git --git-dir=${TRAVIS_BUILD_DIR}/.git add --all  # All modules moved are modules changed to test PR changes
 
 script:

--- a/travis/self_tests
+++ b/travis/self_tests
@@ -5,8 +5,6 @@ import getaddons
 import travis_helpers
 from test_server import get_test_dependencies
 
-import run_pylint
-
 repo_dir = os.environ.get("TRAVIS_BUILD_DIR", "./tests/test_repo/")
 exclude = os.environ.get("EXCLUDE")
 
@@ -42,6 +40,7 @@ assert travis_helpers.yellow_light(u'\ntest\nnewline') == u"\033[33m\033[0;m\n\0
 # Testing empty paths and pylint_run fix of:
 # https://www.mail-archive.com/code-quality@python.org/msg00294.html
 if os.environ.get('LINT_CHECK', 0) == '1':
+    import run_pylint
     pylint_rcfile = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
         'cfg',

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -108,7 +108,7 @@ extra_params_cmd = [
     '--sys-paths', os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
         'pylint_deprecated_modules'),
-    '--extra-params', '--load-plugins=pylint_oca',
+    '--extra-params', '--load-plugins=pylint_odoo',
 ]
 def get_beta_msgs():
     '''Get beta msgs from beta.cfg file

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -1,9 +1,19 @@
 #!/bin/bash
 
-pip install -q QUnitSuite flake8 coveralls Click oca-pylint-plugin pylint-mccabe > /dev/null 2>&1
+if [ "${LINT_CHECK}" != "0" ]; then
+    pip install -q flake8 Click pylint-mccabe
+
+    # Install pylint plugin depends without lxml
+    wget -q https://raw.githubusercontent.com/OCA/pylint-odoo/master/requirements.txt -O ${HOME}/maintainer-quality-tools/travis/pylint_odoo_requirements.txt
+    find -L ${HOME}/maintainer-quality-tools/travis -name pylint_odoo_requirements.txt -exec sed -i '/lxml/d'  {} \;  #  lxml depends is too slow
+    pip install --upgrade -r ${HOME}/maintainer-quality-tools/travis/pylint_odoo_requirements.txt
+    pip install --upgrade --pre --no-deps git+https://github.com/OCA/pylint-odoo.git   # To use last version ever
+    npm install -g jshint  # Extra package for pylint-odoo plugin
+    exit 0
+fi
 
 # We can exit here and do nothing if this only a LINT check
-if [ "${LINT_CHECK}" == "1" ] ; then
+if [ "${TESTS}" != "1" ] && [ "${LINT_CHECK}" == "1" ]; then
     exit 0
 fi
 
@@ -25,6 +35,7 @@ tar -xf odoo.tar.gz -C ${HOME}
 rm -f $VIRTUAL_ENV/lib/python2.7/no-global-site-packages.txt
 
 pip install --user -q -r $(dirname ${BASH_SOURCE[0]})/requirements.txt
+pip install -q QUnitSuite coveralls
 
 # Use reference .coveragerc
 cp ${HOME}/maintainer-quality-tools/cfg/.coveragerc .


### PR DESCRIPTION
 - Use new pylint_odoo package fix OCA/maintainer-quality-tools#268
 - Install `pylint_odoo` packages only is necessary.