### PR TITLE
[REF] pylint_beta.cfg: Add deprecated module in beta messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,10 @@ env:
   - INCLUDE="test_module,second_module" UNIT_TEST="1"
   - VERSION="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # ODOO_REPO usage example
   - VERSION="6.1" INCLUDE="test_module,second_module"
-  - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="18" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
-  - VERSION=master LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="25" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
-  - VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="21" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
-  - VERSION="" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="18" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
+  - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="15" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
+  - VERSION=master LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="15" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
+  - VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="15" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
+  - VERSION="" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="15" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
 
 install:
   - cp -r ../maintainer-quality-tools/ $HOME

--- a/travis/cfg/travis_run_pylint.cfg
+++ b/travis/cfg/travis_run_pylint.cfg
@@ -11,7 +11,6 @@ disable=all
 #   anomalous-backslash-in-string - W1401
 #   assignment-from-none - W1111
 #   dangerous-default-value - W0102
-#   deprecated-module - W0402
 #   duplicate-key - W0109
 #   file-ignored - I0013
 #   pointless-statement - W0104
@@ -27,7 +26,6 @@ disable=all
 enable=anomalous-backslash-in-string,
     assignment-from-none,
     dangerous-default-value,
-    deprecated-module,
     duplicate-key,
     file-ignored,
     pointless-statement,
@@ -57,7 +55,3 @@ ignore-docstrings=yes
 
 [MISCELLANEOUS]
 notes=
-
-[IMPORTS]
-deprecated-modules=pdb,pudb,ipdb
-

--- a/travis/cfg/travis_run_pylint_beta.cfg
+++ b/travis/cfg/travis_run_pylint_beta.cfg
@@ -6,6 +6,7 @@
 #   class-camelcase - C8104
 #   copy-wo-api-one - W8102
 #   dangerous-filter-wo-user - W7901
+#   deprecated-module - W0402
 #   duplicate-xml-record-id - W7902
 #   incoherent-interpreter-exec-perm - W8201
 #   manifest-deprecated-key - C8103
@@ -25,6 +26,7 @@ enabled2beta=api-one-multi-together,
     class-camelcase,
     copy-wo-api-one,
     dangerous-filter-wo-user,
+    deprecated-module,
     duplicate-xml-record-id,
     incoherent-interpreter-exec-perm,
     manifest-deprecated-key,


### PR DESCRIPTION
Disable error [W0402(deprecated-module), ] Uses of a deprecated module 'openerp.osv'
Now show warning beta message

This PR fix the thread "Maintainer-quality-tools multiple quick changes" sent to contributors email.
