### PR TITLE
[IMP] pylint_pr.cfg: Add new checks from pylint-odoo

### DIFF
--- a/travis/cfg/travis_run_pylint_beta.cfg
+++ b/travis/cfg/travis_run_pylint_beta.cfg
@@ -2,16 +2,21 @@
 #  pylint configuration file will display them without affecting your build status.
 
 # Beta message and code:
+#   api-one-deprecated - W8104
 #   api-one-multi-together - W8101
+#   attribute-deprecated - W8105
 #   class-camelcase - C8104
 #   copy-wo-api-one - W8102
 #   dangerous-filter-wo-user - W7901
 #   deprecated-module - W0402
 #   duplicate-xml-record-id - W7902
 #   incoherent-interpreter-exec-perm - W8201
+#   javascript-lint - W7903
+#   license-allowed - C8105
 #   manifest-deprecated-key - C8103
 #   manifest-required-author - C8101
 #   manifest-required-key - C8102
+#   method-required-super - W8106
 #   missing-readme - C7902
 #   no-utf8-coding-comment - C8201
 #   openerp-exception-warning - R8101
@@ -22,16 +27,21 @@
 #   xml-syntax-error - E7902
 
 [MESSAGES CONTROL]
-enabled2beta=api-one-multi-together,
+enabled2beta=api-one-deprecated,
+    api-one-multi-together,
+    attribute-deprecated,
     class-camelcase,
     copy-wo-api-one,
     dangerous-filter-wo-user,
     deprecated-module,
     duplicate-xml-record-id,
     incoherent-interpreter-exec-perm,
+    javascript-lint,
+    license-allowed,
     manifest-deprecated-key,
     manifest-required-author,
     manifest-required-key,
+    method-required-super,
     missing-readme,
     no-utf8-coding-comment,
     openerp-exception-warning,

--- a/travis/cfg/travis_run_pylint_exclude_61.cfg
+++ b/travis/cfg/travis_run_pylint_exclude_61.cfg
@@ -15,7 +15,7 @@ disable=copy-wo-api-one,
     class-camelcase,
     missing-readme,
     openerp-exception-warning,
+    attribute-deprecated,
 
 [IMPORTS]
 deprecated-modules=pdb,pudb,ipdb
-

--- a/travis/cfg/travis_run_pylint_exclude_70.cfg
+++ b/travis/cfg/travis_run_pylint_exclude_70.cfg
@@ -15,6 +15,7 @@ disable=copy-wo-api-one,
     class-camelcase,
     missing-readme,
     openerp-exception-warning,
+    attribute-deprecated,
 
 [IMPORTS]
 deprecated-modules=pdb,pudb,ipdb

--- a/travis/cfg/travis_run_pylint_pr.cfg
+++ b/travis/cfg/travis_run_pylint_pr.cfg
@@ -13,21 +13,29 @@ readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/templat
 manifest_required_author="Odoo Community Association (OCA)"
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
+attribute_deprecated=_fields,_defaults
+method_required_super=create,write,read,unlink,copy,setUp,tearDown,default_get
+license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,Other OSI approved licence,Other proprietary
 
 [MESSAGES CONTROL]
 disable=all
 
 # Enable message and code:
+#   api-one-deprecated - W8104
 #   api-one-multi-together - W8101
+#   attribute-deprecated - W8105
 #   class-camelcase - C8104
 #   copy-wo-api-one - W8102
 #   dangerous-filter-wo-user - W7901
 #   deprecated-module - W0402
 #   duplicate-xml-record-id - W7902
 #   incoherent-interpreter-exec-perm - W8201
+#   javascript-lint - W7903
+#   license-allowed - C8105
 #   manifest-deprecated-key - C8103
 #   manifest-required-author - C8101
 #   manifest-required-key - C8102
+#   method-required-super - W8106
 #   missing-readme - C7902
 #   no-utf8-coding-comment - C8201
 #   openerp-exception-warning - R8101
@@ -37,16 +45,21 @@ disable=all
 #   use-vim-comment - W8202
 #   xml-syntax-error - E7902
     
-enable=api-one-multi-together,
+enable=api-one-deprecated,
+    api-one-multi-together,
+    attribute-deprecated,
     class-camelcase,
     copy-wo-api-one,
     dangerous-filter-wo-user,
     deprecated-module,
     duplicate-xml-record-id,
     incoherent-interpreter-exec-perm,
+    javascript-lint,
+    license-allowed,
     manifest-deprecated-key,
     manifest-required-author,
     manifest-required-key,
+    method-required-super,
     missing-readme,
     no-utf8-coding-comment,
     openerp-exception-warning,


### PR DESCRIPTION
Enable next pr and beta checks
 -  api-one-deprecated - W8104 - Now is a decorator deprecated see more info [here](https://github.com/OCA/maintainer-tools/blob/master/CONTRIBUTING.md#field)
 -  attribute-deprecated - W8105 - _fields and _defaults Except in odoo 6.1
 -  javascript-lint - W7903 - Use of jshint script.
 -  license-allowed - C8105 - AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,Other OSI approved licence,Other proprietary (all from [odoo] (https://github.com/odoo/odoo/blob/57168a9e90066ed6b3d274d5032a20bef342a00f/openerp/addons/base/module/module.py#L283-L292))
 -  method-required-super - W8106 - Next method require a `super` call create,write,read,unlink,copy,setUp,tearDown,default_get (Extracted with `rgrep -B10 super . --include=*.py` in official modules)

The configuration of this PR is:

| msg  | 9.0  | 8.0  | 7.0  | 6.1  | is beta msg?    |   PR or branches  |
|---|---|---|---|---|---|---|
|   api-one-deprecated  |   yes |   yes |   n/a |   n/a |    [yes] (https://github.com/vauxoo-dev/maintainer-quality-tools/blob/oca-master-enables/travis/cfg/travis_run_pylint_beta.cfg#L30-L52)  |   [PR](https://github.com/vauxoo-dev/maintainer-quality-tools/blob/oca-master-enables/travis/cfg/travis_run_pylint_pr.cfg#L48-L70)  |
|   Attribute-deprecated    |   yes |   yes |   [no](https://github.com/vauxoo-dev/maintainer-quality-tools/blob/oca-master-enables/travis/cfg/travis_run_pylint_exclude_70.cfg#L18)  |  [no](https://github.com/vauxoo-dev/maintainer-quality-tools/blob/oca-master-enables/travis/cfg/travis_run_pylint_exclude_61.cfg#L18)  |   [yes] (https://github.com/vauxoo-dev/maintainer-quality-tools/blob/oca-master-enables/travis/cfg/travis_run_pylint_beta.cfg#L30-L52) |   [PR](https://github.com/vauxoo-dev/maintainer-quality-tools/blob/oca-master-enables/travis/cfg/travis_run_pylint_pr.cfg#L48-L70)  |
|   Javascript-lint |   yes |   yes |   yes |   n/a |    [yes] (https://github.com/vauxoo-dev/maintainer-quality-tools/blob/oca-master-enables/travis/cfg/travis_run_pylint_beta.cfg#L30-L52)  |   [PR](https://github.com/vauxoo-dev/maintainer-quality-tools/blob/oca-master-enables/travis/cfg/travis_run_pylint_pr.cfg#L48-L70)  |
|   license-allowed |   yes |   yes |   yes |   yes |    [yes] (https://github.com/vauxoo-dev/maintainer-quality-tools/blob/oca-master-enables/travis/cfg/travis_run_pylint_beta.cfg#L30-L52)   |   [PR](https://github.com/vauxoo-dev/maintainer-quality-tools/blob/oca-master-enables/travis/cfg/travis_run_pylint_pr.cfg#L48-L70)  |
|   method-required-super   |   yes |   yes |   yes |   yes |    [yes] (https://github.com/vauxoo-dev/maintainer-quality-tools/blob/oca-master-enables/travis/cfg/travis_run_pylint_beta.cfg#L30-L52) |   [PR](https://github.com/vauxoo-dev/maintainer-quality-tools/blob/oca-master-enables/travis/cfg/travis_run_pylint_pr.cfg#L48-L70)  |
