### PR TITLE
Store dependency repositories in $HOME/dependencies

### DIFF
--- a/travis/clone_oca_dependencies
+++ b/travis/clone_oca_dependencies
@@ -3,7 +3,8 @@
 
 Arguments:
 
-checkout_dir: the directory in which the dependency repositories will be cloned
+deps_checkout_dir: the directory in which the dependency repositories
+will be cloned
 build_dir: the directory in which the tested repositories have been cloned
 
 If no arguments are provided, default to the layout used in the OCA travis
@@ -32,12 +33,6 @@ import logging
 
 _logger = logging.getLogger()
 
-travis_repo_slug = os.environ.get(
-    "TRAVIS_REPO_SLUG",
-    "OCA/maintainer-quality-tools",
-)
-travis_repo_owner = travis_repo_slug.split("/")[0]
-
 
 def parse_depfile(depfile, owner='OCA'):
     deps = []
@@ -59,8 +54,8 @@ def parse_depfile(depfile, owner='OCA'):
     return deps
 
 
-def git_checkout(home, reponame, url, branch):
-    checkout_dir = osp.join(home, reponame)
+def git_checkout(deps_checkout_dir, reponame, url, branch):
+    checkout_dir = osp.join(deps_checkout_dir, reponame)
     if not osp.isdir(checkout_dir):
         command = ['git', 'clone', '-q', url, '-b', branch, checkout_dir]
         _logger.info('Calling %s', ' '.join(command))
@@ -68,13 +63,15 @@ def git_checkout(home, reponame, url, branch):
     return checkout_dir
 
 
-def run(home, build_dir):
+def run(deps_checkout_dir, build_dir):
     dependencies = []
     processed = set()
-    for repo in os.listdir(build_dir):
+    depfilename = osp.join(build_dir, 'oca_dependencies.txt')
+    dependencies.append(depfilename)
+    for repo in os.listdir(deps_checkout_dir):
         _logger.info('examining %s', repo)
         processed.add(repo)
-        depfilename = osp.join(build_dir, repo, 'oca_dependencies.txt')
+        depfilename = osp.join(deps_checkout_dir, repo, 'oca_dependencies.txt')
         dependencies.append(depfilename)
     for depfilename in dependencies:
         try:
@@ -83,11 +80,12 @@ def run(home, build_dir):
         except IOError:
             deps = []
         for depname, url, branch in deps:
-            _logger.info('* processing %s',  depname)
+            _logger.info('* processing %s', depname)
             if depname in processed:
                 continue
             processed.add(depname)
-            checkout_dir = git_checkout(home, depname, url, branch)
+            checkout_dir = git_checkout(deps_checkout_dir, depname,
+                                        url, branch)
             new_dep_filename = osp.join(checkout_dir, 'oca_dependencies.txt')
             if new_dep_filename not in dependencies:
                 dependencies.append(new_dep_filename)
@@ -95,12 +93,14 @@ def run(home, build_dir):
 
 if __name__ == '__main__':
     if len(sys.argv) == 1:
-        home = os.environ['HOME']
-        build_dir = osp.join(home, 'build', travis_repo_owner)
+        deps_checkout_dir = osp.join(os.environ['HOME'], 'dependencies')
+        if not osp.exists(deps_checkout_dir):
+            os.makedirs(deps_checkout_dir)
+        build_dir = os.environ['TRAVIS_BUILD_DIR']
     elif len(sys.argv) == 2 or len(sys.argv) > 3:
         print(__doc__)
         sys.exit(1)
     else:
-        home = sys.argv[1]
+        deps_checkout_dir = sys.argv[1]
         build_dir = sys.argv[2]
-    run(home, build_dir)
+    run(deps_checkout_dir, build_dir)

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -118,15 +118,15 @@ def get_server_path(odoo_full, odoo_version, travis_home):
     return server_path
 
 
-def get_addons_path(travis_home, travis_build_dir, server_path):
+def get_addons_path(travis_dependencies_dir, travis_build_dir, server_path):
     """
     Calculate addons path
-    :param travis_home: Travis home directory
+    :param travis_dependencies_dir: Travis dependencies directory
     :param travis_build_dir: Travis build directory
     :param server_path: Server path
     :return: Addons path
     """
-    addons_path_list = get_addons(travis_home)
+    addons_path_list = get_addons(travis_dependencies_dir)
     addons_path_list.insert(0, travis_build_dir)
     addons_path_list.append(server_path + "/addons")
     addons_path = ','.join(addons_path_list)
@@ -208,6 +208,7 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv
     travis_home = os.environ.get("HOME", "~/")
+    travis_dependencies_dir = os.path.join(travis_home, 'dependencies')
     travis_build_dir = os.environ.get("TRAVIS_BUILD_DIR", "../..")
     odoo_unittest = str2bool(os.environ.get("UNIT_TEST"))
     odoo_exclude = os.environ.get("EXCLUDE")
@@ -235,7 +236,9 @@ def main(argv=None):
             test_loghandler = 'openerp.tools.yaml_import:DEBUG'
     odoo_full = os.environ.get("ODOO_REPO", "odoo/odoo")
     server_path = get_server_path(odoo_full, odoo_version, travis_home)
-    addons_path = get_addons_path(travis_home, travis_build_dir, server_path)
+    addons_path = get_addons_path(travis_dependencies_dir,
+                                  travis_build_dir,
+                                  server_path)
 
     tested_addons_list = get_addons_to_check(travis_build_dir,
                                              odoo_include,

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -55,8 +55,10 @@ clone_oca_dependencies
 #     |___ <OdooRepo>-<Branch>/         <-- Odoo Server
 #     |___ maintainer-quality-tools/
 #     |___ build/<Owner>/<TestedRepo>/
-#     |___ <DependencyRepo1>/
-#     |___ <DependencyRepo2>/
+#     |___ dependencies/<DependencyRepo1>/
+#     |___ dependencies/<DependencyRepo2>/
 #     |...
 echo "Content of ${HOME}:"
 ls -l ${HOME}
+echo "Content of ${HOME}/dependencies:"
+ls -l ${HOME}/dependencies

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ "${LINT_CHECK}" != "0" ]; then
     pip install -q flake8 Click pylint-mccabe
 
@@ -62,3 +64,5 @@ echo "Content of ${HOME}:"
 ls -l ${HOME}
 echo "Content of ${HOME}/dependencies:"
 ls -l ${HOME}/dependencies
+
+set +e

--- a/travis/travis_transifex.py
+++ b/travis/travis_transifex.py
@@ -36,6 +36,7 @@ def main(argv=None):
         return 1
 
     travis_home = os.environ.get("HOME", "~/")
+    travis_dependencies_dir = os.path.join(travis_home, 'dependencies')
     travis_build_dir = os.environ.get("TRAVIS_BUILD_DIR", "../..")
     travis_repo_slug = os.environ.get("TRAVIS_REPO_SLUG")
     travis_repo_owner = travis_repo_slug.split("/")[0]
@@ -70,7 +71,9 @@ def main(argv=None):
 
     odoo_full = os.environ.get("ODOO_REPO", "odoo/odoo")
     server_path = get_server_path(odoo_full, odoo_version, travis_home)
-    addons_path = get_addons_path(travis_home, travis_build_dir, server_path)
+    addons_path = get_addons_path(travis_dependencies_dir,
+                                  travis_build_dir,
+                                  server_path)
     addons_list = get_addons_to_check(travis_build_dir, odoo_include,
                                       odoo_exclude)
     addons = ','.join(addons_list)


### PR DESCRIPTION
Instead of $HOME because other tools that expect to have a directory which
contains only valid addons paths will get confused if other directories are
created in $HOME (e.g. npm creates a 'node_modules' folder).

Follows discussion on #288