### PR TITLE
Do not include inexistent addons path

### DIFF
--- a/travis/getaddons.py
+++ b/travis/getaddons.py
@@ -60,6 +60,8 @@ def is_addons(path):
 
 
 def get_addons(path):
+    if not os.path.exists(path):
+        return []
     if is_addons(path):
         res = [path]
     else:


### PR DESCRIPTION
It allows a build to continue if a build did not create the
'$HOME/dependencies' folder beforehand.

Fixes #293