### PR TITLE
Install node packages globally

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -22,7 +22,7 @@ fi
 
 # Install less
 ln -s `which nodejs` $HOME/maintainer-quality-tools/travis/node
-npm install less less-plugin-clean-css
+npm install -g less less-plugin-clean-css
 
 
 # For backward compatibility, take version from parameter if it's not globally set


### PR DESCRIPTION
`npm install less less-plugin-clean-css` creates a `node_modules` folder in the addons path.
It makes builds that expect to only find addons in the addons path to fail.
Example:
https://travis-ci.org/OCA/connector/jobs/89892364

Using `npm install -g` makes the installation of node modules global so it doesn't pollute the addons path.

Tested on: https://github.com/OCA/connector/pull/146