### PR TITLE
[IMP] test_server: Enable store database (avoid delete it) and allow run a instance alive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
 
 install:
   - cp -r ../maintainer-quality-tools/ $HOME
-  - mv tests/test_repo/* ./
+  - cp -r tests/test_repo/* ./
   - export PATH=$HOME/maintainer-quality-tools/travis:$PATH
   - travis_install_nightly 8.0 # only used if VERSION not set in env
   - pip install coveralls  # Force install coveralls in all cases of MQT for self_test script.

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
   - VERSION="9.0" TESTS="1" LINT_CHECK="0"
 
   matrix:
-  - INCLUDE="broken_module" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
+  - INSTANCE_ALIVE="1" INCLUDE="broken_module" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
   - EXCLUDE="broken_module,broken_lint" OPTIONS="--log-level=debug" INSTALL_OPTIONS="--log-level=info"
   - INCLUDE="test_module,second_module" UNIT_TEST="1"
   - VERSION="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # ODOO_REPO usage example
@@ -48,8 +48,8 @@ install:
   - git --git-dir=${TRAVIS_BUILD_DIR}/.git add --all  # All modules moved are modules changed to test PR changes
 
 script:
-  - coverage run --append ./travis/self_tests
   - coverage run --append ./travis/travis_run_tests 8.0  # only used if VERSION not set in env
+  - coverage run --append ./travis/self_tests
 
 after_success:
   - TESTS="1" LINT_CHECK="0" travis_after_tests_success

--- a/travis/self_tests
+++ b/travis/self_tests
@@ -2,6 +2,9 @@
 
 import os
 import subprocess
+import signal
+import time
+import xmlrpclib
 
 import getaddons
 import travis_helpers
@@ -75,3 +78,43 @@ if os.environ.get('LINT_CHECK', 0) == '1':
 
 # Testing git run from getaddons
 getaddons.get_modules_changed(repo_dir)
+
+
+# Testing instance running
+def connection_test():
+    username = "admin"
+    password = "admin"
+    database_name = "openerp_test"
+    port = 8069
+    host = '127.0.0.1'
+    sock_common = xmlrpclib.ServerProxy(
+        "http://%s:%d/xmlrpc/common" % (host, port))
+    uid = sock_common.login(
+        database_name, username, password)
+    sock = xmlrpclib.ServerProxy(
+        "http://%s:%d/xmlrpc/object" % (host, port))
+    user_ids = sock.execute(
+        database_name, uid, password, 'res.users',
+        'search', [('login', '=', 'admin')])
+    return user_ids
+
+if os.environ.get('INSTANCE_ALIVE') == '1' and os.environ.get('TESTS') == '1':
+    travis_path = os.path.dirname(os.path.abspath(__file__))
+    travis_run_tests = os.path.join(travis_path, 'travis_run_tests')
+    command = ["coverage", "run", "--append", travis_run_tests, "8.0"]
+    env = os.environ
+    stdout = open('travis_run_tests.stdout', 'w')
+    stderr = open('travis_run_tests.stderr', 'w')
+    process = subprocess.Popen(
+        command, stdout=stdout, stderr=stderr,
+        preexec_fn=os.setsid, env=env)
+    for index in range(10):
+        try:
+            connection_result = connection_test()
+        except:
+            connection_result = None
+        if connection_result:
+            break
+        time.sleep(2)
+    os.killpg(process.pid, signal.SIGTERM)
+    assert None != connection_result, "Connection test failed"

--- a/travis/self_tests
+++ b/travis/self_tests
@@ -2,12 +2,13 @@
 
 import os
 import subprocess
-import signal
+import threading
 import time
 import xmlrpclib
 
 import getaddons
 import travis_helpers
+from test_server import main as test_server_main
 from test_server import get_test_dependencies
 
 repo_dir = os.environ.get("TRAVIS_BUILD_DIR", "./tests/test_repo/")
@@ -98,13 +99,17 @@ def connection_test():
         'search', [('login', '=', 'admin')])
     return user_ids
 
+
+class TestServerThread(threading.Thread):
+    def run(self):
+        test_server_main()
+
+
 if os.environ.get('INSTANCE_ALIVE') == '1' and os.environ.get('TESTS') == '1':
-    travis_path = os.path.dirname(os.path.abspath(__file__))
-    travis_run_tests = os.path.join(travis_path, 'travis_run_tests')
-    command = ["coverage", "run", "--append", travis_run_tests, "8.0"]
-    process = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        preexec_fn=os.setsid)
+    thread = TestServerThread()
+    thread.daemon = True
+    thread.start()
+
     for index in range(10):
         try:
             connection_result = connection_test()
@@ -113,5 +118,4 @@ if os.environ.get('INSTANCE_ALIVE') == '1' and os.environ.get('TESTS') == '1':
         if connection_result:
             break
         time.sleep(2)
-    os.killpg(process.pid, signal.SIGTERM)
     assert None != connection_result, "Connection test failed"

--- a/travis/self_tests
+++ b/travis/self_tests
@@ -102,12 +102,9 @@ if os.environ.get('INSTANCE_ALIVE') == '1' and os.environ.get('TESTS') == '1':
     travis_path = os.path.dirname(os.path.abspath(__file__))
     travis_run_tests = os.path.join(travis_path, 'travis_run_tests')
     command = ["coverage", "run", "--append", travis_run_tests, "8.0"]
-    env = os.environ
-    stdout = open('travis_run_tests.stdout', 'w')
-    stderr = open('travis_run_tests.stderr', 'w')
     process = subprocess.Popen(
-        command, stdout=stdout, stderr=stderr,
-        preexec_fn=os.setsid, env=env)
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        preexec_fn=os.setsid)
     for index in range(10):
         try:
             connection_result = connection_test()

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -192,23 +192,20 @@ def setup_server(db, odoo_unittest, tested_addons, server_path,
     if preinstall_modules is None:
         preinstall_modules = ['base']
     print("\nCreating instance:")
-    start_dbtmpl = True
     try:
         subprocess.check_call(["createdb", db])
     except subprocess.CalledProcessError:
-        start_dbtmpl = False
         print("Using previous openerp_template database.")
-    if not start_dbtmpl:
-        return 0
-    cmd_odoo = ["%s/openerp-server" % server_path,
-                "-d", db,
-                "--log-level=warn",
-                "--stop-after-init",
-                "--addons-path", addons_path,
-                "--init", ','.join(preinstall_modules),
-                ] + install_options
-    print(" ".join(cmd_odoo))
-    subprocess.check_call(cmd_odoo)
+    else:
+        cmd_odoo = ["%s/openerp-server" % server_path,
+                    "-d", db,
+                    "--log-level=warn",
+                    "--stop-after-init",
+                    "--addons-path", addons_path,
+                    "--init", ','.join(preinstall_modules),
+                    ] + install_options
+        print(" ".join(cmd_odoo))
+        subprocess.check_call(cmd_odoo)
     return 0
 
 

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -225,7 +225,7 @@ def main(argv=None):
     expected_errors = int(os.environ.get("SERVER_EXPECTED_ERRORS", "0"))
     odoo_version = os.environ.get("VERSION")
     instance_alive = str2bool(os.environ.get('INSTANCE_ALIVE'))
-    is_runbot = str2bool(os.environ.get('RUNBOT'))
+    unbuffer = str2bool(os.environ.get('UNBUFFER', True))
     if not odoo_version:
         # For backward compatibility, take version from parameter
         # if it's not globally set
@@ -325,12 +325,8 @@ def main(argv=None):
                     ['--db-filter=^%s$' % database]
             else:
                 command[-1] = to_test
-                if is_runbot:
-                    command_call = []
-                else:
-                    # Run test command; unbuffer keeps output colors
-                    command_call = ["unbuffer"]
-                command_call += command
+                # Run test command; unbuffer keeps output colors
+                command_call = (["unbuffer"] if unbuffer else []) + command
             print(' '.join(command_call))
             pipe = subprocess.Popen(command_call,
                                     stderr=subprocess.STDOUT,

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -192,22 +192,23 @@ def setup_server(db, odoo_unittest, tested_addons, server_path,
     if preinstall_modules is None:
         preinstall_modules = ['base']
     print("\nCreating instance:")
-    db_tmpl_created = False
+    start_dbtmpl = True
     try:
         subprocess.check_call(["createdb", db])
     except subprocess.CalledProcessError:
-        db_tmpl_created = True
+        start_dbtmpl = False
         print("Using previous openerp_template database.")
-    if not db_tmpl_created:
-        cmd_odoo = ["%s/openerp-server" % server_path,
-                    "-d", db,
-                    "--log-level=warn",
-                    "--stop-after-init",
-                    "--addons-path", addons_path,
-                    "--init", ','.join(preinstall_modules),
-                    ] + install_options
-        print(" ".join(cmd_odoo))
-        subprocess.check_call(cmd_odoo)
+    if not start_dbtmpl:
+        return 0
+    cmd_odoo = ["%s/openerp-server" % server_path,
+                "-d", db,
+                "--log-level=warn",
+                "--stop-after-init",
+                "--addons-path", addons_path,
+                "--init", ','.join(preinstall_modules),
+                ] + install_options
+    print(" ".join(cmd_odoo))
+    subprocess.check_call(cmd_odoo)
     return 0
 
 


### PR DESCRIPTION
 - Useful and fully tested in next runbot-docker https://github.com/OCA/runbot-addons/pull/71
 - Useful to use travis2docker locally and runbot-travis2docker with OCA repositories
 - [REF] .travis.yml: Using cp instead mv to avoid docker/docker#4570

Maybe, this change will can be useful with other CI that use docker to build:
 - [codeship will be use docker](http://pages.codeship.com/webinars/getting-started-with-continuous-delivery-using-docker?utm_campaign=Weekly+Newsletters&utm_source=hs_email&utm_medium=email&utm_content=24008076&_hsenc=p2ANqtz-8m3QJNm6Hk560x3IwMJk94m9oLIiyB7lJNKuIEBpYJQXqajwDdLPQaBW3vj6kqWrZz1qndrnBbyYAlweFdiLxcX_rxlQ&_hsmi=24008076)
 - [shippable use docker](http://docs.shippable.com/)
