### PR TITLE
[REF] clone_oca_dependencies: Add feature to upgrade git version of repositories dependencie

### DIFF
--- a/travis/clone_oca_dependencies
+++ b/travis/clone_oca_dependencies
@@ -58,8 +58,11 @@ def git_checkout(deps_checkout_dir, reponame, url, branch):
     checkout_dir = osp.join(deps_checkout_dir, reponame)
     if not osp.isdir(checkout_dir):
         command = ['git', 'clone', '-q', url, '-b', branch, checkout_dir]
-        _logger.info('Calling %s', ' '.join(command))
-        subprocess.check_call(command)
+    else:
+        command = ['git', '--git-dir=' + os.path.join(checkout_dir, '.git'),
+                   '--work-tree=' + checkout_dir, 'pull', url, branch]
+    _logger.info('Calling %s', ' '.join(command))
+    subprocess.check_call(command)
     return checkout_dir
 
 

--- a/travis/clone_oca_dependencies
+++ b/travis/clone_oca_dependencies
@@ -60,7 +60,8 @@ def git_checkout(deps_checkout_dir, reponame, url, branch):
         command = ['git', 'clone', '-q', url, '-b', branch, checkout_dir]
     else:
         command = ['git', '--git-dir=' + os.path.join(checkout_dir, '.git'),
-                   '--work-tree=' + checkout_dir, 'pull', url, branch]
+                   '--work-tree=' + checkout_dir, 'pull', '--ff-only',
+                   url, branch]
     _logger.info('Calling %s', ' '.join(command))
     subprocess.check_call(command)
     return checkout_dir


### PR DESCRIPTION
 - If you run 2 times the `clone_oca_dependencies` script you will get:
  - First time: `git clone ...`
  - Second time: `git pull ...` 
 - Update repositories dependencies previously downloaded.
 - Useful when you use MQT locally to upgrade repositories