### PR TITLE
[FIX] Apply patch taken from OCA/maintainer-quality-tools#249

### DIFF
--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -281,6 +281,8 @@ def main(argv=None):
     dbtemplate = "openerp_template"
     preinstall_modules = get_test_dependencies(addons_path,
                                                tested_addons_list)
+    preinstall_modules = list(set(preinstall_modules) - set(get_modules(
+        os.environ.get('TRAVIS_BUILD_DIR'))))
     print("Modules to preinstall: %s" % preinstall_modules)
     setup_server(dbtemplate, odoo_unittest, tested_addons, server_path,
                  addons_path, install_options, preinstall_modules)


### PR DESCRIPTION
## Change log 
- The change presented here comes from #249 where preinstalled modules in testing instance are getting some of the modules to be unit tested. So, in some cases may lead to errors like are currently happening in 8.0 branch for OCA/rma

For example there is [travis#103328194](https://travis-ci.org/OCA/rma/jobs/103328194):

Where the module **`crm_rma_lot_mass_return`** appears in both lists:
```bash
Modules to test: crm_claim_product_supplier,crm_claim_rma,crm_claim_rma_code,
crm_rma_advance_warranty,crm_rma_claim_make_claim,crm_rma_location,
crm_rma_lot_mass_return,crm_rma_prodlot_invoice,crm_rma_prodlot_supplier,
crm_rma_stock_location,product_warranty
```
```bash
Modules to preinstall: ['product_unique_serial', 'crm_rma_lot_mass_return', 
'purchase', 'crm_claim_type', 'product', 'sale', 'procurement', 'base', 
'crm_claim_code', 'crm_claim', 'stock', 'sale_stock', 'sales_team', 'stock_account']
```

And the normal (or correct) behavior should be that **`crm_rma_lot_mass_return`** module should be only in modules to be tested and not preinstalled ones.

## Note
- All the credit for this patch goes to @moylop260

## Things to do:
- [x] Wait and check results for OCA/rma#73