### PR TITLE
[IMP] clone_oca_dependencies: pip install requirements.txt

### DIFF
--- a/travis/clone_oca_dependencies
+++ b/travis/clone_oca_dependencies
@@ -68,11 +68,15 @@ def run(deps_checkout_dir, build_dir):
     processed = set()
     depfilename = osp.join(build_dir, 'oca_dependencies.txt')
     dependencies.append(depfilename)
+    reqfilenames = []
     for repo in os.listdir(deps_checkout_dir):
         _logger.info('examining %s', repo)
         processed.add(repo)
         depfilename = osp.join(deps_checkout_dir, repo, 'oca_dependencies.txt')
         dependencies.append(depfilename)
+        reqfilename = osp.join(build_dir, repo, 'requirements.txt')
+        if osp.isfile(reqfilename):
+            reqfilenames.append(reqfilename)
     for depfilename in dependencies:
         try:
             with open(depfilename) as depfile:
@@ -87,8 +91,15 @@ def run(deps_checkout_dir, build_dir):
             checkout_dir = git_checkout(deps_checkout_dir, depname,
                                         url, branch)
             new_dep_filename = osp.join(checkout_dir, 'oca_dependencies.txt')
+            reqfilename = osp.join(checkout_dir, 'requirements.txt')
+            if osp.isfile(reqfilename):
+                reqfilenames.append(reqfilename)
             if new_dep_filename not in dependencies:
                 dependencies.append(new_dep_filename)
+    for reqfilename in reqfilenames:
+        command = ['pip', 'install', '-r', reqfilename]
+        _logger.info('Calling %s', ' '.join(command))
+        subprocess.check_call(command)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 - If main project and/or projects depends exists a `requirements.txt` then will be used to install.
   - `pip install -r requirements.txt`
 - Allow install depends recursively between projects.
 - Allow use a global standard to install python dependencies.