### PR TITLE
Revert "[IMP] Add images to required keys of manifest file"

### DIFF
--- a/travis/cfg/travis_run_pylint_pr.cfg
+++ b/travis/cfg/travis_run_pylint_pr.cfg
@@ -11,7 +11,7 @@ cache-size=500
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
 manifest_required_author="Odoo Community Association (OCA)"
-manifest_required_keys=license,images
+manifest_required_keys=license
 manifest_deprecated_keys=description,active
 
 [MESSAGES CONTROL]


### PR DESCRIPTION
Reverts OCA/maintainer-quality-tools#298

Opened discuss from @lepistone comment:
https://github.com/OCA/maintainer-quality-tools/pull/298#issuecomment-176651653

>Sorry I came late to the party, but I :-1: the `images` check (so I :+1: @StefanRijnhart "can we revert this").
For me "warning" means something is wrong, but for some reason it doesn't crash the program (or the build or whatever). It is still something you want to get rid of. So in general I think we shouldn't add warnings unless we think they should be enforced one day.
In that case I have the impression it is not always relevant, especially if it is a random screenshot (much less important than documentation, for example).