### PR TITLE
[REF] test_server: Enable live output and fix Build-times-out-because-no-output-was-received

### DIFF
--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -378,7 +378,7 @@ def main(argv=None):
                                     stderr=subprocess.STDOUT,
                                     stdout=subprocess.PIPE)
             with open('stdout.log', 'w') as stdout:
-                for line in pipe.stdout:
+                for line in iter(pipe.stdout.readline, ''):
                     stdout.write(line)
                     print(line.strip())
             returncode = pipe.wait()

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -200,7 +200,7 @@ def setup_server(db, odoo_unittest, tested_addons, server_path,
     else:
         cmd_odoo = ["%s/openerp-server" % server_path,
                     "-d", db,
-                    "--log-level=warn",
+                    "--log-level=info",
                     "--stop-after-init",
                     "--init", ','.join(preinstall_modules),
                     ] + install_options


### PR DESCRIPTION
- [x] [REF] test_server: Add live output to `openerp_template` database.
- [x] [REF] test_server: Add live output to `openerp_test` database
- Allow get a live output to know the current status
- Allow to know a unusual large step without wait the full timeout of the build
  - e.g. A accidental `pdb` or `raw_input`
- Avoid the travis error of [Build-times-out-because-no-output-was-received](https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received)
- Avoid use `travis_wait` script.

Example of enabled live output [video](https://youtu.be/fG1LIG4prTs)