### PR TITLE
allow to ignore a file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ env:
   - INCLUDE="test_module,second_module" UNIT_TEST="1"
   - VERSION="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # ODOO_REPO usage example
   - VERSION="6.1" INCLUDE="test_module,second_module"
-  - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="15" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
-  - VERSION=master EXCLUDE="broken_no_access_rule" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="16" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
-  - VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="16" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
-  - VERSION="" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="15" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
+  - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="14" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
+  - VERSION=master EXCLUDE="broken_no_access_rule" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="15" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
+  - VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="15" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
+  - VERSION="" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="14" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
   - INCLUDE="broken_no_access_rule" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
 
 install:

--- a/tests/test_repo/broken_module/I0013.py
+++ b/tests/test_repo/broken_module/I0013.py
@@ -1,1 +1,0 @@
-# pylint: skip-file

--- a/travis/cfg/travis_run_pylint.cfg
+++ b/travis/cfg/travis_run_pylint.cfg
@@ -12,7 +12,6 @@ disable=all
 #   assignment-from-none - W1111
 #   dangerous-default-value - W0102
 #   duplicate-key - W0109
-#   file-ignored - I0013
 #   pointless-statement - W0104
 #   pointless-string-statement - W0105
 #   print-statement - E1601
@@ -27,7 +26,6 @@ enable=anomalous-backslash-in-string,
     assignment-from-none,
     dangerous-default-value,
     duplicate-key,
-    file-ignored,
     pointless-statement,
     pointless-string-statement,
     print-statement,


### PR DESCRIPTION
Pylint allows you to ignore a file completely adding a "# pylint: disable-all"
line at the top. This is especially useful in cases where a file is
copied for some reason and we don't want to mess too much with it to
avoid diverging from the original. This option make the "disable-all"
option an error, rather confusingly.