### PR TITLE
[REF] travis_run_tests: Avoid false red from forks for transifex builds

### DIFF
--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -61,7 +61,7 @@ if __name__ == '__main__':
     is_pull_request = os.environ.get('TRAVIS_PULL_REQUEST') != 'false'
     # Avoid false red from forks using OCA transifex user
     is_valid_transifex = not is_pull_request and \
-        is_oca_project == is_oca_transifex_user
+        (is_oca_project or not is_oca_transifex_user)
 
     # Test list. Each test is a list with command + arguments.
     tests = []

--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -53,9 +53,15 @@ if __name__ == '__main__':
     tests_enabled = os.environ.get('TESTS') == '1'
     tests_unspecified = os.environ.get('TESTS') is None
     transifex_enabled = os.environ.get('TRANSIFEX') == '1'
+    is_oca_project = os.environ.get('TRAVIS_REPO_SLUG', '').startswith('OCA/')
+    is_oca_transifex_user = os.environ.get('TRANSIFEX_USER') == \
+        'transbot@odoo-community.org'
 
     # TRAVIS_PULL_REQUEST contains the pull request number or 'false'
     is_pull_request = os.environ.get('TRAVIS_PULL_REQUEST') != 'false'
+    # Avoid false red from forks using OCA transifex user
+    is_valid_transifex = not is_pull_request and \
+        is_oca_project == is_oca_transifex_user
 
     # Test list. Each test is a list with command + arguments.
     tests = []
@@ -70,7 +76,7 @@ if __name__ == '__main__':
     elif tests_enabled:
         tests.append(['test_server.py'])
 
-    if transifex_enabled and not is_pull_request:
+    if transifex_enabled and is_valid_transifex:
         tests.append(['travis_transifex.py'])
 
     if tests:


### PR DESCRIPTION
Closes https://github.com/OCA/maintainer-quality-tools/issues/339 and https://github.com/OCA/maintainer-quality-tools/issues/334

If you want help the travis request
https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix
`Please take into account that Travis CI is an open source service and we rely on worker boxes provided by the community. So please only specify as big a matrix as you actually need.`
You could apply the following change in your own fork:
```patch
===.travis.yml
-   - TRANSIFEX="1"
+   # - TRANSIFEX="1"
```

But if you want let your fork repository without changes with this PR won't see a false red.

FYI this change is compatible with other not oca projects using OCA/MQT with `TRANSIFEX_USER="not_oca_user@mycompany.com"` to manage translations.

FYI I'm using TRAVIS_REPO_SLUG from [Default environment variables of travis](https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables)

I added a dummy commit to see the result:
https://travis-ci.org/OCA/maintainer-quality-tools/jobs/143446713#L245
![screen shot 2016-07-08 at 4 33 34 pm](https://cloud.githubusercontent.com/assets/6644187/16702132/bd491e48-4529-11e6-845b-0a68c8c037f5.png)
