### PR TITLE
[ADD] Enable codecov: Show a extra github statuses focused for just changes

### DIFF
--- a/travis/travis_after_tests_success
+++ b/travis/travis_after_tests_success
@@ -4,8 +4,10 @@ import os
 
 from coverage.cmdline import main as coverage_main
 from coveralls import cli as coveralls_cli
+from codecov import main as codecov_main
 
 if (os.environ.get('TESTS', '1') == '1' and
         not os.environ.get('LINT_CHECK') == '1'):
     coverage_main(["report", "--show-missing"])
-    exit(coveralls_cli.main(argv=None))
+    coveralls_cli.main(argv=None)
+    codecov_main(argv=None)

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -43,7 +43,7 @@ tar -xf odoo.tar.gz -C ${HOME}
 rm -f $VIRTUAL_ENV/lib/python2.7/no-global-site-packages.txt
 
 pip install --user -q -r $(dirname ${BASH_SOURCE[0]})/requirements.txt
-pip install -q QUnitSuite coveralls
+pip install -q QUnitSuite coveralls codecov
 
 # Use reference .coveragerc
 cp ${HOME}/maintainer-quality-tools/cfg/.coveragerc .


### PR DESCRIPTION
Coveralls.io is failing too much recently.
I good example is this PR (I don't have changes affecting by monitored py files):
![coveralls](https://cloud.githubusercontent.com/assets/6644187/16782180/067cce76-4844-11e6-85be-1d24333274bc.png)

Codecov adds an additional and useful github statuses to split a average of coverage just of your diff.

![codecov](https://cloud.githubusercontent.com/assets/6644187/16782275/61c14050-4844-11e6-8b55-d562be16e856.png)


 - Codecov have integrate [browser plugins](https://github.com/codecov/browser-extension)