### PR TITLE
Update travis scripts to install with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ During testbed setup, MQT will automatically download and place these repositori
 Note on addons path ordering: They will be placed after your own repo, but before the odoo core repo.
 
 If `oca_dependencies.txt` is not present, Dependencies outside the repository will be automatically installed from
-https://wheelhouse.odoo-community.org/oca and https://pypi.python.org
+[pypi](https://pypi.python.org).
 
 
 Check your .travis file for syntax issues.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ If your project depends on other OCA or other Github repositories, create a file
 During testbed setup, MQT will automatically download and place these repositories accordingly into the addon path.
 Note on addons path ordering: They will be placed after your own repo, but before the odoo core repo.
 
+If `oca_dependencies.txt` is not present, Dependencies outside the repository will be automatically installed from
+https://wheelhouse.odoo-community.org/oca and https://pypi.python.org
+
+
 Check your .travis file for syntax issues.
 ------------------------------------------
 

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -133,10 +133,16 @@ def get_addons_path(travis_dependencies_dir, travis_build_dir, server_path):
     addons_path_list = get_addons(travis_build_dir)
     addons_path_list.extend(get_addons(travis_dependencies_dir))
     addons_path_list.append(os.path.join(server_path, "addons"))
-    site_package_addons = os.environ['VIRTUAL_ENV'] + \
-        "/lib/python2.7/site-packages/odoo_addons"
-    if os.path.isdir(site_package_addons):
-        addons_path_list.append(site_package_addons)
+    try:
+        ap = __import__('odoo_addons').__path__
+        addons_path_list.extend(ap)
+    except ImportError:
+        pass
+    try:
+        ap = __import__('odoo.addons').addons.__path__
+        addons_path_list.extend(ap)
+    except ImportError:
+        pass
     addons_path = ','.join(addons_path_list)
     return addons_path
 

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import sys
+
 from getaddons import get_addons, get_modules, is_installable_module
 from travis_helpers import success_msg, fail_msg
 
@@ -132,6 +133,10 @@ def get_addons_path(travis_dependencies_dir, travis_build_dir, server_path):
     addons_path_list = get_addons(travis_build_dir)
     addons_path_list.extend(get_addons(travis_dependencies_dir))
     addons_path_list.append(os.path.join(server_path, "addons"))
+    site_package_addons = os.environ['VIRTUAL_ENV'] + \
+        "/lib/python2.7/site-packages/odoo_addons"
+    if os.path.isdir(site_package_addons):
+        addons_path_list.append(site_package_addons)
     addons_path = ','.join(addons_path_list)
     return addons_path
 

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -67,20 +67,41 @@ fi
 
 # Workaround to force using system site packages (see https://github.com/Shippable/support/issues/241#issuecomment-57947925)
 rm -f $VIRTUAL_ENV/lib/python2.7/no-global-site-packages.txt
-pip install --upgrade pip
+
+echo "Installing MQT requirements"
+pip install --upgrade "pip>=8.1.0"
 pip install --user -q --no-binary pycparser -r $(dirname ${BASH_SOURCE[0]})/requirements.txt
 pip install -q QUnitSuite coveralls codecov
 
 # Use reference .coveragerc
 cp ${HOME}/maintainer-quality-tools/cfg/.coveragerc .
 
-echo "Getting addons dependencies"
-clone_oca_dependencies
-clone_result=$?
-if [ "$clone_result" != "0"  ]; then
-    echo "Error cloning dependencies"
-    exit $clone_result
-fi;
+if [ -f "oca_dependencies.txt" ]; then
+    echo "Getting addons dependencies"
+    clone_oca_dependencies
+    clone_result=$?
+    if [ "$clone_result" != "0" ]; then
+        echo "Error cloning dependencies"
+        exit $clone_result
+    fi
+else
+    echo "Installing Odoo"
+    pip install -e ${HOME}/${REPO[1]}-${VERSION}
+    echo "Installing addons and dependencies"
+    pip install setuptools-odoo
+    setuptools-odoo-make-default -d .
+    for addon in $(ls setup/ -I README) ; do
+        echo "-e ./setup/$addon" >> requirements.txt
+    done
+    cat requirements.txt
+    # use --pre to get .devN versions from the wheelhouse
+    pip install --pre -r requirements.txt -f https://wheelhouse.odoo-community.org/oca
+    install_result=$?
+    if [ "$install_result" != "0"  ]; then
+        echo "Error installing addons and dependencies"
+        exit $install_result
+    fi
+fi
 
 echo "Install webkit (wkhtmltopdf) patched"
 (cd ${HOME}/maintainer-quality-tools/travis/ && wget -qO- http://download.gna.org/wkhtmltopdf/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz | tar -xJ --strip-components=2 wkhtmltox/bin/wkhtmltopdf)
@@ -99,5 +120,13 @@ ls -l ${HOME}
 
 echo "Content of ${HOME}/dependencies:"
 mkdir -p ${HOME}/dependencies && ls -l ${HOME}/dependencies
+echo "pip installed packages:"
+echo VIRTUAL_ENV=$VIRTUAL_ENV
+echo PATH=$PATH
+which pip
+which python
+pip --version
+python -c "import sys; print sys.path"
+pip list
 
 set +e

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -76,7 +76,7 @@ pip install -q QUnitSuite coveralls codecov
 # Use reference .coveragerc
 cp ${HOME}/maintainer-quality-tools/cfg/.coveragerc .
 
-if [ -f "oca_dependencies.txt" ]; then
+if [ -f "oca_dependencies.txt" ] || [ $(echo "$VERSION <= 7.0" | bc) -eq "1" ]; then
     echo "Getting addons dependencies"
     clone_oca_dependencies
     clone_result=$?

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -94,8 +94,8 @@ else
         echo "-e ./setup/$addon" >> requirements.txt
     done
     cat requirements.txt
-    # use --pre to get .devN versions from the wheelhouse
-    pip install --pre -r requirements.txt -f https://wheelhouse.odoo-community.org/oca
+    # use --pre to get .devN versions
+    pip install --pre -r requirements.txt
     install_result=$?
     if [ "$install_result" != "0"  ]; then
         echo "Error installing addons and dependencies"


### PR DESCRIPTION
This is a proof of concept to illustrate how installing with pip can help with dependency management.

There is no need for oca_dependencies.txt anymore as all dependencies are expressed in the `__openerp__.py`, possibly refined by `setup.py`, itself refined by `requirements.txt` if present.

This is IMHO a important enabler to progressively move towards smaller repos.

An example build with this PR is here: https://travis-ci.org/acsone/account-financial-reporting/builds/144847025 (including cross-repo dependencies).

If there is interest, I can finish this PR (ie update mqt test suite mainly).
