### PR TITLE
[REF] test_server: Add test-enable optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,11 @@ To avoid making again these checks on other builds, you have to add
 LINT_CHECK="0" variable on the line:
 
     - VERSION="7.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
+
+
+Disable test
+------------
+If you want to make a build without tests, you can add use the environment variable:
+`TEST_ENABLE="0"`
+
+You will get the databases with packages installed but without run test.

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -273,6 +273,7 @@ def main(argv=None):
     instance_alive = str2bool(os.environ.get('INSTANCE_ALIVE'))
     unbuffer = str2bool(os.environ.get('UNBUFFER', True))
     data_dir = os.environ.get("DATA_DIR", '~/data_dir')
+    test_enable = str2bool(os.environ.get('TEST_ENABLE', True))
     if not odoo_version:
         # For backward compatibility, take version from parameter
         # if it's not globally set
@@ -284,7 +285,8 @@ def main(argv=None):
         install_options += ["--test-disable"]
         test_loglevel = 'test'
     else:
-        options += ["--test-enable"]
+        if test_enable:
+            options += ["--test-enable"]
         if odoo_version == '7.0':
             test_loglevel = 'test'
         else:

--- a/travis/travis_after_tests_success
+++ b/travis/travis_after_tests_success
@@ -5,7 +5,9 @@ import os
 from coverage.cmdline import main as coverage_main
 from coveralls import cli as coveralls_cli
 
+
 if (os.environ.get('TESTS', '1') == '1' and
+        os.environ.get('TEST_ENABLE', '1') == '1' and
         not os.environ.get('LINT_CHECK') == '1'):
     coverage_main(["report", "--show-missing"])
     exit(coveralls_cli.main(argv=None))


### PR DESCRIPTION
 - Use  `TEST_ENABLE=0` if you want run a odoo instance without parameter `--test-enable` to avoid run tests
 - This parameter is useful for runbot based on MQT scripts where we don't like run tests