### PR TITLE
[IMP] coveragerc: Ignore NotImplementedError

### DIFF
--- a/cfg/.coveragerc
+++ b/cfg/.coveragerc
@@ -18,3 +18,5 @@ exclude_lines =
     pragma: no cover
     # Don't complain about null context checking
     if context is None:
+    # Don't check obviously not implemented
+    raise NotImplementedError


### PR DESCRIPTION
This PR adds `NotImplementedError` to ignores in `.coveragerc` - which is generating what I consider to be false positives in some modules. Seems a bit redundant to be testing something that is clearly not implemented IMO