### PR TITLE
[REF] travis_install_nightly: Installing odoo from cache (if exists)

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -31,13 +31,25 @@ if [ "x${VERSION}" == "x" ] ; then
     echo "WARNING: no env variable set for VERSION. Using '${1}'."
 fi
 
-: ${ODOO_REPO:="odoo/odoo"}  # default value, if not set
-IFS="/" read -a REPO <<< "${ODOO_REPO}"
-ODOO_URL="https://github.com/${REPO[0]}/${REPO[1]}/archive/${VERSION}.tar.gz"
-
-echo "Installing Odoo ${ODOO_URL}"
-wget -nv -O odoo.tar.gz ${ODOO_URL}
-tar -xf odoo.tar.gz -C ${HOME}
+if [ -z "${REPO_CACHED}"  ]; then
+    : ${ODOO_REPO:="odoo/odoo"}  # default value, if not set
+    IFS="/" read -a REPO <<< "${ODOO_REPO}"
+    ODOO_URL="https://github.com/${REPO[0]}/${REPO[1]}/archive/${VERSION}.tar.gz"
+    echo "Installing Odoo ${ODOO_URL}"
+    wget -nv -O odoo.tar.gz ${ODOO_URL}
+    tar -xf odoo.tar.gz -C ${HOME}
+else
+    echo "Using Odoo from cache ${REPO_CACHED}"
+    export REMOTE=$(python -c "print '${REPO[0]}'.lower()")
+    export BRANCH=$(python -c "print '${VERSION}'.lower()")
+    export ODOO_PATH=${HOME}/${REPO[1]}-${BRANCH}
+    chown `(whoami)`:`(whoami)` -R ${REPO_CACHED}
+    ln -sf ${REPO_CACHED}/odoo ${ODOO_PATH}
+    cd ${ODOO_PATH} \
+        && git fetch --depth=1 ${REMOTE} ${BRANCH} \
+        && git config --local --bool core.bare false \
+        && git checkout -b ${BRANCH}-${REMOTE} -qf ${REMOTE}/${BRANCH}
+fi
 
 # Workaround to force using system site packages (see https://github.com/Shippable/support/issues/241#issuecomment-57947925)
 rm -f $VIRTUAL_ENV/lib/python2.7/no-global-site-packages.txt

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -33,9 +33,9 @@ fi
 
 : ${ODOO_REPO:="odoo/odoo"}  # default value, if not set
 IFS="/" read -a REPO <<< "${ODOO_REPO}"
-export REMOTE=$(python -c "print '${REPO[0]}'.lower()")
-export REPO_NAME=$(python -c "print '${REPO[1]}'.lower()")
-export BRANCH=$(python -c "print '${VERSION}'.lower()")
+export REMOTE="${REPO[0],,}"
+export REPO_NAME="${REPO[1],,}"
+export BRANCH="${VERSION,,}"
 export ODOO_PATH=${HOME}/$REPO_NAME-$BRANCH
 if [ -z "${REPO_CACHED}"  ]; then
     export ODOO_URL="https://github.com/$REMOTE/$REPO_NAME/archive/$BRANCH.tar.gz"
@@ -44,7 +44,7 @@ if [ -z "${REPO_CACHED}"  ]; then
     tar -xf odoo.tar.gz -C ${HOME}
 else
     echo "Using Odoo from cache ${REPO_CACHED}"
-    chown `(whoami)`:`(whoami)` -R ${REPO_CACHED}
+    chown `(whoami)`:`(id -gn)` -R ${REPO_CACHED}
     ln -sf ${REPO_CACHED}/odoo ${ODOO_PATH}
     cd ${ODOO_PATH} \
         && git fetch --depth=1 ${REMOTE} ${BRANCH} \

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -31,18 +31,19 @@ if [ "x${VERSION}" == "x" ] ; then
     echo "WARNING: no env variable set for VERSION. Using '${1}'."
 fi
 
+: ${ODOO_REPO:="odoo/odoo"}  # default value, if not set
+IFS="/" read -a REPO <<< "${ODOO_REPO}"
+export REMOTE=$(python -c "print '${REPO[0]}'.lower()")
+export REPO_NAME=$(python -c "print '${REPO[1]}'.lower()")
+export BRANCH=$(python -c "print '${VERSION}'.lower()")
+export ODOO_PATH=${HOME}/$REPO_NAME-$BRANCH
 if [ -z "${REPO_CACHED}"  ]; then
-    : ${ODOO_REPO:="odoo/odoo"}  # default value, if not set
-    IFS="/" read -a REPO <<< "${ODOO_REPO}"
-    ODOO_URL="https://github.com/${REPO[0]}/${REPO[1]}/archive/${VERSION}.tar.gz"
-    echo "Installing Odoo ${ODOO_URL}"
-    wget -nv -O odoo.tar.gz ${ODOO_URL}
+    export ODOO_URL="https://github.com/$REMOTE/$REPO_NAME/archive/$BRANCH.tar.gz"
+    echo "Installing Odoo $ODOO_URL"
+    wget -nv -O odoo.tar.gz $ODOO_URL
     tar -xf odoo.tar.gz -C ${HOME}
 else
     echo "Using Odoo from cache ${REPO_CACHED}"
-    export REMOTE=$(python -c "print '${REPO[0]}'.lower()")
-    export BRANCH=$(python -c "print '${VERSION}'.lower()")
-    export ODOO_PATH=${HOME}/${REPO[1]}-${BRANCH}
     chown `(whoami)`:`(whoami)` -R ${REPO_CACHED}
     ln -sf ${REPO_CACHED}/odoo ${ODOO_PATH}
     cd ${ODOO_PATH} \


### PR DESCRIPTION
If exists a caching git directory with odoo we can re-use it just for update last changes faster after last cached date.
- Useful for [runbot dockerized based on MQT](https://github.com/OCA/runbot-addons/tree/9.0/runbot_travis2docker)
- Useful for [travis caching](https://docs.travis-ci.com/user/caching/)

Example where works
 - Runbot build: http://runbot.vauxoo.com/runbot/repo/git-github-com-vauxoo-crm-git-35
    - Log: http://runbot.vauxoo.com/runbot/static/build/17286-8-0-2ca7ea/logs/job_10_test_base.txt