### PR TITLE
[ADD] travis: Add server_options

### DIFF
--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -181,7 +181,7 @@ def get_test_dependencies(addons_path, addons_list):
 
 def setup_server(db, odoo_unittest, tested_addons, server_path,
                  addons_path, install_options, preinstall_modules=None,
-                 unbuffer=True):
+                 unbuffer=True, server_options=None):
     """
     Setup the base module before running the tests
     if the database template exists then will be used.
@@ -192,6 +192,7 @@ def setup_server(db, odoo_unittest, tested_addons, server_path,
     :param travis_build_dir: path to the modules to be tested
     :param addons_path: Addons path
     :param install_options: Install options (travis parameter)
+    :param server_options: (list) Add these flags to the Odoo server init
     """
     if preinstall_modules is None:
         preinstall_modules = ['base']
@@ -208,7 +209,7 @@ def setup_server(db, odoo_unittest, tested_addons, server_path,
                      "--log-level=info",
                      "--stop-after-init",
                      "--init", ','.join(preinstall_modules),
-                     ] + install_options
+                     ] + install_options + server_options
         print(" ".join(cmd_odoo))
         subprocess.check_call(cmd_odoo)
     return 0
@@ -268,6 +269,7 @@ def main(argv=None):
     odoo_include = os.environ.get("INCLUDE")
     options = os.environ.get("OPTIONS", "").split()
     install_options = os.environ.get("INSTALL_OPTIONS", "").split()
+    server_options = os.environ.get('SERVER_OPTIONS', "").split()
     expected_errors = int(os.environ.get("SERVER_EXPECTED_ERRORS", "0"))
     odoo_version = os.environ.get("VERSION")
     instance_alive = str2bool(os.environ.get('INSTANCE_ALIVE'))
@@ -322,7 +324,8 @@ def main(argv=None):
         os.environ.get('TRAVIS_BUILD_DIR'))))
     print("Modules to preinstall: %s" % preinstall_modules)
     setup_server(dbtemplate, odoo_unittest, tested_addons, server_path,
-                 addons_path, install_options, preinstall_modules, unbuffer)
+                 addons_path, install_options, preinstall_modules, unbuffer,
+                 server_options)
 
     # Running tests
     database = "openerp_test"
@@ -344,7 +347,8 @@ def main(argv=None):
                             "-d", database,
                             "--stop-after-init",
                             "--log-level=warn",
-                            ] + install_options + ["--init", None]
+                            ] + install_options + ["--init", None] +\
+                            server_options
         commands = ((cmd_odoo_install, False),
                     (cmd_odoo_test, True),
                     )


### PR DESCRIPTION
This PR adds additional server_options flag in order to allow the ability to pass additional options to the server init, outside of the standard Travis options.

This is required in order to allow Runbot-Travis2Docker to pass the necessary [`--log-db`](https://github.com/odoo/odoo-extra/blob/master/runbot/runbot.py#L897) command to the underlying server. Using the pre-existing options would allow for overwrite via the Travis file, which is undesired.

* Add `SERVER_OPTIONS` env var
* Append server_options to relevant build commands