### PR TITLE
[REF] .travis.yml: Update PYLINT_EXPECTED_ERRORS to new version of pylint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ env:
   - INCLUDE="test_module,second_module" UNIT_TEST="1"
   - VERSION="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # ODOO_REPO usage example
   - VERSION="6.1" INCLUDE="test_module,second_module"
-  - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="14" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
-  - VERSION=master EXCLUDE="broken_no_access_rule" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="19" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
-  - VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="19" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
-  - VERSION="" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="14" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
+  - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="17" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
+  - VERSION=master EXCLUDE="broken_no_access_rule" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="22" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
+  - VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="22" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
+  - VERSION="" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="17" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
   - INCLUDE="broken_no_access_rule" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
 
 install:


### PR DESCRIPTION
 - The new version of [pylint-odoo](https://github.com/OCA/pylint-odoo/pull/69) detects a re-import with `alias import`, then the expected errors should be increased because we have imported 3 times the `Warning` library