### PR TITLE
[REF] test_pylint: Use valid_odoo_versions from version environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
   - VERSION="6.1" INCLUDE="test_module,second_module"
   - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="21" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
   - VERSION=master EXCLUDE="broken_no_access_rule" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="26" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
-  - VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="22" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
+  - VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="24" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
   - VERSION="" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="21" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
   - INCLUDE="broken_no_access_rule" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
 

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -147,7 +147,7 @@ if version:
         extra_params_cmd.extend([
             '--extra-params', extra_param
         ])
-    is_version_number = re.match('\d+.\d+', version)
+    is_version_number = re.match(r'\d+.\d+', version)
     if is_version_number:
         extra_params_cmd.extend([
             '--extra-params', '--valid_odoo_versions=%s' % version])

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -147,7 +147,7 @@ if version:
         extra_params_cmd.extend([
             '--extra-params', extra_param
         ])
-    is_version_number = re.match(r'\d+.\d+', version)
+    is_version_number = re.match(r'\d+\.\d+', version)
     if is_version_number:
         extra_params_cmd.extend([
             '--extra-params', '--valid_odoo_versions=%s' % version])

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -44,6 +44,7 @@ Use the following types of pylint configuration files:
 
 
 import os
+import re
 import ConfigParser
 
 import run_pylint
@@ -146,6 +147,10 @@ if version:
         extra_params_cmd.extend([
             '--extra-params', extra_param
         ])
+    is_version_number = re.match('\d+.\d+', version)
+    if is_version_number:
+        extra_params_cmd.extend([
+            '--extra-params', '--valid_odoo_versions=%s' % version])
 else:
     print(travis_helpers.yellow('Undefined environment variable `VERSION`.'
           '\nSet `VERSION` for compatibility with guidelines by version.'))


### PR DESCRIPTION
Second part of https://github.com/OCA/pylint-odoo/pull/77

Full fix https://github.com/OCA/maintainer-quality-tools/issues/366