### PR TITLE
[FIX] Graceful coverage failures

### DIFF
--- a/travis/travis_after_tests_success
+++ b/travis/travis_after_tests_success
@@ -11,5 +11,11 @@ if (os.environ.get('TESTS', '1') == '1' and
         os.environ.get('TEST_ENABLE', '1') == '1' and
         not os.environ.get('LINT_CHECK') == '1'):
     coverage_main(["report", "--show-missing"])
-    coveralls_cli.main(argv=None)
-    codecov_main(argv=None)
+    try:
+        coveralls_cli.main(argv=None)
+    except:
+        pass
+    try:
+        codecov_main(argv=None)
+    except:
+        pass


### PR DESCRIPTION
* Guard coverage calls to fail gracefully - both libraries output the error via logging, we don’t want to exit

Without this if coveralls fails due to no project existing, CodeCov will not be attempted. This means that BOTH Coveralls and CodeCov accounts are required to output coverage only via CodeCov.

I went ahead and guarded both though, because I didn't see any reason why not.