### PR TITLE
Recursive module search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,16 +26,16 @@ env:
   - VERSION="9.0" TESTS="1" LINT_CHECK="0"
 
   matrix:
-  - INSTANCE_ALIVE="1" INCLUDE="broken_module" SERVER_EXPECTED_ERRORS="2"  # test errors are detected
-  - EXCLUDE="broken_module,broken_lint,broken_no_access_rule" OPTIONS="--log-level=debug" INSTALL_OPTIONS="--log-level=info" RUN_COMMAND_MQT_CREATE_FOLDER='mkdir /tmp/tests'
-  - INCLUDE="test_module,second_module" UNIT_TEST="1"
-  - VERSION="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # ODOO_REPO usage example
-  - VERSION="6.1" INCLUDE="test_module,second_module"
-  - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="21" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
-  - VERSION=master EXCLUDE="broken_no_access_rule" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="26" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
-  - VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="24" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
-  - VERSION="" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="21" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
-  - INCLUDE="broken_no_access_rule" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
+  - INSTANCE_ALIVE="1" INCLUDE="broken_module" SERVER_EXPECTED_ERRORS="2"  # 1:test errors are detected
+  - EXCLUDE="broken_module,broken_lint,broken_no_access_rule" OPTIONS="--log-level=debug" INSTALL_OPTIONS="--log-level=info" RUN_COMMAND_MQT_CREATE_FOLDER='mkdir /tmp/tests'  # 2
+  - INCLUDE="test_module,second_module" UNIT_TEST="1"  # 3:
+  - VERSION="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # 4: ODOO_REPO usage example
+  - VERSION="6.1" INCLUDE="test_module,second_module"  #5:
+  - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="21" TRAVIS_PULL_REQUEST="false" # 6: Use main pylint config file
+  - VERSION=master EXCLUDE="broken_no_access_rule" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="26" TRAVIS_PULL_REQUEST="true"  # 7:Use PR pylint config file
+  - VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="24" TRAVIS_PULL_REQUEST="true"  # 8: To check pylint_conf of PR's with old api
+  - VERSION="" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="21" TRAVIS_PULL_REQUEST="false"  # 9: To check VERSION empty or unset case.
+  - INCLUDE="broken_no_access_rule" SERVER_EXPECTED_ERRORS="1"  # 10: test errors are detected
 
 install:
   - cp -r ../maintainer-quality-tools/ $HOME

--- a/git/pre-commit
+++ b/git/pre-commit
@@ -11,6 +11,6 @@ status1=$?
 flake8 . --config=${FLAKE8_CONFIG_DIR}/travis_run_flake8.cfg
 status2=$?
 
-TRAVIS_PULL_REQUEST="true" TRAVIS_BRANCH="HEAD" TRAVIS_BUILD_DIR=`pwd -P` $(dirname $0)/test_pylint
+PYLINT_RECURSIVE="true" TRAVIS_PULL_REQUEST="true" TRAVIS_BRANCH="HEAD" TRAVIS_BUILD_DIR=`pwd -P` $(dirname $0)/test_pylint
 pylint_status=$?
 exit $((${status1} || ${status2} || ${pylint_status}))

--- a/travis/cfg/travis_run_flake8.cfg
+++ b/travis/cfg/travis_run_flake8.cfg
@@ -3,4 +3,4 @@
 # F811 is legal in odoo 8 when we implement 2 interfaces for a method
 ignore = E123,E133,E226,E241,E242,F811
 max-line-length = 79
-exclude = __unported__,__init__.py
+exclude = __unported__,__init__.py,odoo

--- a/travis/cfg/travis_run_flake8__init__.cfg
+++ b/travis/cfg/travis_run_flake8__init__.cfg
@@ -3,6 +3,6 @@
 # F401 is legal in odoo __init__.py files
 ignore = E123,E133,E226,E241,E242,F401
 max-line-length = 79
-exclude = __unported__
+exclude = __unported__,odoo
 filename = __init__.py
 

--- a/travis/cfg/travis_run_pylint_pr.cfg
+++ b/travis/cfg/travis_run_pylint_pr.cfg
@@ -4,7 +4,7 @@
 
 [MASTER]
 profile=no
-ignore=CVS,.git,scenarios,.bzr
+ignore=CVS,.git,scenarios,.bzr,odoo,config
 persistent=yes
 cache-size=500
 

--- a/travis/getaddons.py
+++ b/travis/getaddons.py
@@ -19,7 +19,7 @@ MANIFEST_FILES = [
     '__terp__.py',
 ]
 
-EXCLUDED_DIR = ['odoo', 'config']
+EXCLUDED_DIR = ['odoo', 'config', 'travis', 'git', 'cfg', 'sample_files']
 
 
 def is_module(path):

--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -3,13 +3,12 @@
 
 from __future__ import print_function
 
-import os
-import sys
-
 import click
 import pylint.lint
+import sys
 
 import getaddons
+
 
 CLICK_DIR = click.Path(exists=True, dir_okay=True, resolve_path=True)
 
@@ -24,31 +23,6 @@ def get_count_fails(linter_stats, msgs_no_count=None):
         linter_stats['by_msg'][msg]
         for msg in linter_stats['by_msg']
         if msg not in msgs_no_count])
-
-
-def get_subpaths(paths):
-    """Get list of subdirectories
-    if `__init__.py` file not exists in root path then
-    get subdirectories.
-    Why? More info here:
-        https://www.mail-archive.com/code-quality@python.org/msg00294.html
-    :param paths: List of paths
-    :return: Return list of paths with subdirectories.
-    """
-    subpaths = []
-    for path in paths:
-        if not os.path.isfile(os.path.join(path, '__init__.py')):
-            subpaths.extend(
-                [os.path.join(path, item)
-                 for item in os.listdir(path)
-                 if os.path.isfile(os.path.join(path, item, '__init__.py')) and
-                 (not getaddons.is_module(os.path.join(path, item)) or
-                  getaddons.is_installable_module(os.path.join(path, item)))])
-        else:
-            if not getaddons.is_module(path) or \
-                    getaddons.is_installable_module(path):
-                subpaths.append(path)
-    return subpaths
 
 
 def run_pylint(paths, cfg, beta_msgs=None, sys_paths=None, extra_params=None):
@@ -67,7 +41,9 @@ def run_pylint(paths, cfg, beta_msgs=None, sys_paths=None, extra_params=None):
     sys.path.extend(sys_paths)
     cmd = ['--rcfile=' + cfg]
     cmd.extend(extra_params)
-    subpaths = get_subpaths(paths)
+
+    subpaths = getaddons.get_subpaths(paths)
+
     if not subpaths:
         raise UserWarning("Python modules not found in paths"
                           " {paths}".format(paths=paths))

--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -42,7 +42,7 @@ def run_pylint(paths, cfg, beta_msgs=None, sys_paths=None, extra_params=None):
     cmd = ['--rcfile=' + cfg]
     cmd.extend(extra_params)
 
-    subpaths = getaddons.get_subpaths(paths)
+    subpaths = getaddons.get_subpaths(paths, subpaths=[])
 
     if not subpaths:
         raise UserWarning("Python modules not found in paths"

--- a/travis/self_tests
+++ b/travis/self_tests
@@ -7,9 +7,10 @@ import time
 import xmlrpclib
 
 import getaddons
-import travis_helpers
-from test_server import main as test_server_main
 from test_server import get_test_dependencies
+from test_server import main as test_server_main
+import travis_helpers
+
 
 repo_dir = os.environ.get("TRAVIS_BUILD_DIR", "./tests/test_repo/")
 exclude = os.environ.get("EXCLUDE")
@@ -20,7 +21,7 @@ to_preinstall = get_test_dependencies(repo_dir, addons_list)
 assert not [x for x in to_preinstall if x in addons_list], \
     "Should not preinstall modules to test!"
 
-# Testing getaddons
+print('# Testing getaddons')
 assert getaddons.main() == 1
 getaddons.main(["getaddons.py", repo_dir])
 getaddons.main(["getaddons.py", "-m", repo_dir])
@@ -30,20 +31,29 @@ if exclude:
     getaddons.main(["getaddons.py", "-m", repo_dir, "-e", exclude])
     getaddons.main(["getaddons.py", "-e", exclude, repo_dir])
 
-# Testing travis helpers
+print('# Testing travis helpers')
 assert travis_helpers.red(u'test') == u"\033[1;31mtest\033[0;m"
 assert travis_helpers.green(u'test') == u"\033[1;32mtest\033[0;m"
 assert travis_helpers.yellow(u'test') == u"\033[1;33mtest\033[0;m"
 assert travis_helpers.yellow_light(u'test') == u"\033[33mtest\033[0;m"
 
 
-assert travis_helpers.red(u'\ntest\nnewline') == u"\033[1;31m\033[0;m\n\033[1;31mtest\033[0;m\n\033[1;31mnewline\033[0;m"
-assert travis_helpers.green(u'\ntest\nnewline') == u"\033[1;32m\033[0;m\n\033[1;32mtest\033[0;m\n\033[1;32mnewline\033[0;m"
-assert travis_helpers.yellow(u'\ntest\nnewline') == u"\033[1;33m\033[0;m\n\033[1;33mtest\033[0;m\n\033[1;33mnewline\033[0;m"
-assert travis_helpers.yellow_light(u'\ntest\nnewline') == u"\033[33m\033[0;m\n\033[33mtest\033[0;m\n\033[33mnewline\033[0;m"
+assert travis_helpers.red(
+    u'\ntest\nnewline') == \
+    u"\033[1;31m\033[0;m\n\033[1;31mtest\033[0;m\n\033[1;31mnewline\033[0;m"
+assert travis_helpers.green(
+    u'\ntest\nnewline') == \
+    u"\033[1;32m\033[0;m\n\033[1;32mtest\033[0;m\n\033[1;32mnewline\033[0;m"
+assert travis_helpers.yellow(
+    u'\ntest\nnewline') == \
+    u"\033[1;33m\033[0;m\n\033[1;33mtest\033[0;m\n\033[1;33mnewline\033[0;m"
+assert travis_helpers.yellow_light(
+    u'\ntest\nnewline') == \
+    u"\033[33m\033[0;m\n\033[33mtest\033[0;m\n\033[33mnewline\033[0;m"
 
 
-# Testing empty paths and pylint_run fix of:
+print('# Testing empty paths')
+#  and pylint_run fix of:
 # https://www.mail-archive.com/code-quality@python.org/msg00294.html
 if os.environ.get('LINT_CHECK', 0) == '1':
     import run_pylint
@@ -51,6 +61,8 @@ if os.environ.get('LINT_CHECK', 0) == '1':
         os.path.dirname(os.path.realpath(__file__)),
         'cfg',
         "travis_run_pylint.cfg")
+
+    print("Run pylint first time for path: %s", repo_dir)
     count_errors = run_pylint.main([
         "--config-file=" + pylint_rcfile,
         "--extra-params", "-d", "--extra-params", "all",
@@ -61,6 +73,7 @@ if os.environ.get('LINT_CHECK', 0) == '1':
     empty_path = os.path.join(repo_dir, 'empty_path')
     if not os.path.exists(empty_path):
         os.mkdir(empty_path)
+    print("Run pylint second time for empty_path: %s", empty_path)
     count_errors = run_pylint.main([
         "--config-file=" + pylint_rcfile,
         "--path", empty_path], standalone_mode=False)
@@ -69,6 +82,8 @@ if os.environ.get('LINT_CHECK', 0) == '1':
     if os.environ.get('TRAVIS_PULL_REQUEST', 'false') != 'false':
         git_script_path = os.path.join(os.path.dirname(
             os.path.dirname(os.path.realpath(__file__))), 'git')
+        print(travis_helpers.yellow_light(
+            "================= Test pre-commit ================"))
         pre_commit_returned = subprocess.call(os.path.join(
             git_script_path, 'pre-commit'))
         assert pre_commit_returned == 0, \
@@ -77,7 +92,7 @@ if os.environ.get('LINT_CHECK', 0) == '1':
 # Testing git get branch
 
 
-# Testing git run from getaddons
+print('# Testing git run from getaddons')
 getaddons.get_modules_changed(repo_dir)
 
 
@@ -101,6 +116,7 @@ def connection_test():
 
 
 class TestServerThread(threading.Thread):
+
     def run(self):
         test_server_main()
 
@@ -118,4 +134,6 @@ if os.environ.get('INSTANCE_ALIVE') == '1' and os.environ.get('TESTS') == '1':
         if connection_result:
             break
         time.sleep(2)
-    assert None != connection_result, "Connection test failed"
+    assert connection_result is not None, "Connection test failed"
+
+print(travis_helpers.green("Self_tests pass"))

--- a/travis/test_flake8
+++ b/travis/test_flake8
@@ -11,7 +11,7 @@ flake8_config_dir = os.path.join(root_dir, 'cfg')
 
 status = 0
 
-for addon in get_modules(os.path.abspath('.')):
+for addon in get_modules(os.path.abspath('.'), return_modules_path=True):
     status += subprocess.call(['flake8', addon,
                                '--config=%s/travis_run_flake8__init__.cfg' %
                                flake8_config_dir])

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -42,16 +42,14 @@ Use the following types of pylint configuration files:
   File name: `travis_run_pylint_beta.cfg`
 """
 
-
+import ConfigParser
 import os
 import re
-import ConfigParser
-
-import run_pylint
-import travis_helpers
 
 from getaddons import get_modules_changed
 from git_run import GitRun
+import run_pylint
+import travis_helpers
 
 
 def get_extra_params(odoo_version):
@@ -116,6 +114,8 @@ extra_params_cmd = [
         'pylint_deprecated_modules'),
     '--extra-params', '--load-plugins=pylint_odoo',
 ]
+
+
 def get_beta_msgs():
     '''Get beta msgs from beta.cfg file
     :return: List of strings with beta message names'''
@@ -152,8 +152,9 @@ if version:
         extra_params_cmd.extend([
             '--extra-params', '--valid_odoo_versions=%s' % version])
 else:
-    print(travis_helpers.yellow('Undefined environment variable `VERSION`.'
-          '\nSet `VERSION` for compatibility with guidelines by version.'))
+    print(travis_helpers.yellow(
+        'Undefined environment variable `VERSION`.'
+        '\nSet `VERSION` for compatibility with guidelines by version.'))
 
 
 beta_msgs = get_beta_msgs()
@@ -173,17 +174,17 @@ pylint_rcfile = os.path.join(
     pylint_config_file)
 count_errors = run_pylint.main([
     "--config-file=" + pylint_rcfile,
-    ] + extra_params_cmd, standalone_mode=False)
+] + extra_params_cmd, standalone_mode=False)
 
 pylint_rcfile_pr = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
     'cfg',
     "travis_run_pylint_pr.cfg")
 
-
 if is_pull_request and branch_base and git_work_dir:
     if branch_base != 'HEAD':
         branch_base = 'origin/' + branch_base
+
     modules_changed = get_modules_changed(
         git_work_dir,
         branch_base)
@@ -219,9 +220,9 @@ if count_errors == -1:
     print(travis_helpers.yellow('Python modules not found'))
 elif count_errors != expected_errors:
     print(travis_helpers.red("pylint expected errors {expected_errors}, "
-          "found {number_errors}!".format(
-              expected_errors=expected_errors,
-              number_errors=count_errors)))
+                             "found {number_errors}!".format(
+                                 expected_errors=expected_errors,
+                                 number_errors=count_errors)))
     exit_status = 1
 if beta_msgs and count_errors >= 0:
     print(travis_helpers.green(

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -2,11 +2,12 @@
 
 from __future__ import print_function
 
-import re
 import os
+import re
 import shutil
 import subprocess
 import sys
+
 from getaddons import get_addons, get_modules, is_installable_module
 from travis_helpers import success_msg, fail_msg
 
@@ -28,13 +29,13 @@ def has_test_errors(fname, dbname, odoo_version, check_loaded=True):
     errors_ignore = [
         'Mail delivery failed',
         'failed sending mail',
-        ]
+    ]
     errors_report = [
         lambda x: x['loglevel'] == 'CRITICAL',
         'At least one test failed',
         'no access rules, consider adding one',
         'invalid module names, ignored',
-        ]
+    ]
     # Only check ERROR lines before 7.0
     if odoo_version < '7.0':
         errors_report.append(
@@ -54,7 +55,7 @@ def has_test_errors(fname, dbname, odoo_version, check_loaded=True):
     make_pattern_list_callable(errors_ignore)
     make_pattern_list_callable(errors_report)
 
-    print("-"*10)
+    print("-" * 10)
     # Read log file removing ASCII color escapes:
     # http://serverfault.com/questions/71285
     color_regex = re.compile(r'\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]')
@@ -95,7 +96,7 @@ def has_test_errors(fname, dbname, odoo_version, check_loaded=True):
     if errors:
         for e in errors:
             print(e['message'])
-        print("-"*10)
+        print("-" * 10)
     return len(errors)
 
 

--- a/travis/travis_helpers.py
+++ b/travis/travis_helpers.py
@@ -3,7 +3,6 @@
 helpers shared by the various QA tools
 """
 
-
 RED = "\033[1;31m"
 GREEN = "\033[1;32m"
 YELLOW = "\033[1;33m"


### PR DESCRIPTION
### Objective
Encourage the use of maintainers quality tool when working on any project, not only OCA.

At Trobz (and I know for sure that we are not the only one), we use this method:
- One repo that contains all the code necessary for the project
- Part of this repo are subtrees (others can use sub-modules) for the common repositories of OCA or common internally
- The final repository structure is:
for a complete project with the below structure:
  - Project repo
    - addons
      - hr: oca hr repository as subtree / sub-modules
      - server-tools: oca server-tools repository as subtree / sub-modules
      - my_project_modules
        - my_module_1
        - my_module_2
    - odoo: subtree / sub-modules of odoo source code

### Issue faced
Maintainer quality tools assume that all the python modules are located directly in the repository.

Something like this:

- hr: the oca repository
  - hr_xxx: the modules

Tools does not discover modules located in sub-sub-folders or deeper, instead you get this message `Python modules not found`.

Note: This problem is specific to pylint tests, flake 8 tests run beautifully discovering all python code.

### Added Feature
Enable checks even when modules are not located directly in the root folder.

### Personal note
I am quite new to maintainers quality tool (my first commit here after using only few days) so I might miss something on how to use maintainer-quality-tool that would make this PR useless.