### PR TITLE
[FIX] travis_install_nightly: Fixing ODOO_PATH when is OCB (uppercase) used

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -34,8 +34,8 @@ fi
 : ${ODOO_REPO:="odoo/odoo"}  # default value, if not set
 IFS="/" read -a REPO <<< "${ODOO_REPO}"
 export REMOTE="${REPO[0],,}"
-export REPO_NAME="${REPO[1],,}"
-export BRANCH="${VERSION,,}"
+export REPO_NAME="${REPO[1]}"
+export BRANCH="${VERSION}"
 export ODOO_PATH=${HOME}/$REPO_NAME-$BRANCH
 if [ -z "${REPO_CACHED}"  ]; then
     export ODOO_URL="https://github.com/$REMOTE/$REPO_NAME/archive/$BRANCH.tar.gz"


### PR DESCRIPTION
Currently runbot show the following [log](https://runbot2.odoo-community.org/runbot/static/build/3272576-8-0-ee406d/logs/job_20_test_all.txt)

```bash
...
Creating instance:
~/OCB-8.0/openerp-server -d openerp_template --log-level=info --stop-after-init --init product,base,stock
[Errno 2] No such file or directory

+=======================================
|  Tests summary:
|---------------------------------------
| test_server.py              FAIL
+=======================================
```

MQT is not finding `~/OCB-8.0` (uppercase) path because the folder is created with lowercase
<img width="166" alt="screen shot 2016-11-17 at 5 27 30 am" src="https://cloud.githubusercontent.com/assets/6644187/20387554/4716d106-ac86-11e6-9ae4-75674fde9250.png">


[test_server.py#L303-L304](https://github.com/OCA/maintainer-quality-tools/blob/e86286bdf325b61188ca25f1b14f8211e4f6bc89/travis/test_server.py#L303-L304) is using original name (without upper or lowercase transformation)
This PR create 2 scripts consistent

NOTE: The REMOTE is the unique variable that require lowercase, this value is from main image of docker.