### PR TITLE
[FIX] getaddons lint

### DIFF
--- a/travis/getaddons.py
+++ b/travis/getaddons.py
@@ -128,5 +128,6 @@ def main(argv=None):
         res = [x for x in res if x not in exclude_modules]
     print(','.join(res))
 
+
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Without this fix, when running  pylint-odoo, I get this error of flake

```
FLAKE8_CONFIG_DIR="$(dirname $0)/cfg"
dirname $0

flake8 . --config=${FLAKE8_CONFIG_DIR}/travis_run_flake8__init__.cfg
status1=$?
flake8 . --config=${FLAKE8_CONFIG_DIR}/travis_run_flake8.cfg
./.git/hooks/getaddons.py:131:1: E305 expected 2 blank lines after class or function definition, found 1
status2=$?

TRAVIS_PULL_REQUEST="true" TRAVIS_BRANCH="HEAD" TRAVIS_BUILD_DIR=`pwd -P` $(dirname $0)/test_pylint
dirname $0
pwd -P

```