### PR TITLE
[REF] maintainer-quality-tools: Use eslint instead of jshint for javascript lints

### DIFF
--- a/tests/test_repo/broken_module/broken_example.js
+++ b/tests/test_repo/broken_module/broken_example.js
@@ -1,0 +1,7 @@
+$(document).ready(function () {
+    $('.example').each(function () {
+        var oe_website_sale = this;
+    }) /*missing semicolon*/
+    /*Use of console log*/
+    console.log("This is similar to a print");
+}) /*missing semicolon*/

--- a/tests/test_repo/broken_module/broken_example2.js
+++ b/tests/test_repo/broken_module/broken_example2.js
@@ -1,0 +1,7 @@
+/*Use of "+function" instead of "Number(function" */
++function ($) {
+  'use strict';
+  var var_1 = "value1";
+  var var_2 = "value2";
+};
+/* Newline required at end of file but not found */

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -10,8 +10,15 @@ if [ "${LINT_CHECK}" != "0" ]; then
     find -L ${HOME}/maintainer-quality-tools/travis -name pylint_odoo_requirements.txt -exec sed -i '/lxml/d'  {} \;  #  lxml depends is too slow
     pip install --upgrade -r ${HOME}/maintainer-quality-tools/travis/pylint_odoo_requirements.txt
     pip install --upgrade --pre --no-deps git+https://github.com/OCA/pylint-odoo.git   # To use last version ever
-    npm install -g jshint  # Extra package for pylint-odoo plugin
-    exit 0
+    npm install -g eslint  # Extra package for pylint-odoo plugin
+    if [ -f "${HOME}/.nvm/nvm.sh" ]; then
+        # Update nodejs v6.latest required by eslint
+        # Using nvm of travis
+        CURRENT_NODE=$(which node)
+        source ${HOME}/.nvm/nvm.sh
+        nvm install 6
+        ln -sf $(nvm which 6) $CURRENT_NODE
+    fi
 fi
 
 # We can exit here and do nothing if this only a LINT check


### PR DESCRIPTION
More info: https://github.com/OCA/pylint-odoo/pull/97

- Fix exit early if you want test both: `LINT_CHECK="1" TESTS="1"`

TODO:
- [x] Update this branch after merge the CI fixes: https://github.com/OCA/maintainer-quality-tools/pull/390 to get a green
- [ ] Create other PR to update expected errors after merge this one and https://github.com/OCA/pylint-odoo/pull/97