### PR TITLE
[FIX] Fixes CI result

### DIFF
--- a/tests/test_repo/broken_module/test.yml
+++ b/tests/test_repo/broken_module/test.yml
@@ -2,4 +2,4 @@
   Inject a test error
 -
   !assert {model: res.users, id: base.user_demo, string: Generated failure}:
-    - False
+    - "False"

--- a/travis/cfg/travis_run_flake8.cfg
+++ b/travis/cfg/travis_run_flake8.cfg
@@ -1,6 +1,7 @@
 [flake8]
 # E123,E133,E226,E241,E242 are ignored by default by pep8 and flake8
 # F811 is legal in odoo 8 when we implement 2 interfaces for a method
-ignore = E123,E133,E226,E241,E242,F811
+# F999 pylint support this case with expected tests
+ignore = E123,E133,E226,E241,E242,F811,F999
 max-line-length = 79
 exclude = __unported__,__init__.py

--- a/travis/cfg/travis_run_flake8__init__.cfg
+++ b/travis/cfg/travis_run_flake8__init__.cfg
@@ -1,7 +1,8 @@
 [flake8]
 # E123,E133,E226,E241,E242 are ignored by default by pep8 and flake8
 # F401 is legal in odoo __init__.py files
-ignore = E123,E133,E226,E241,E242,F401
+# F999 pylint support this case with expected tests
+ignore = E123,E133,E226,E241,E242,F401,F999
 max-line-length = 79
 exclude = __unported__
 filename = __init__.py

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -434,5 +434,6 @@ def main(argv=None):
     # if we get here, all is OK
     return 0
 
+
 if __name__ == '__main__':
     exit(main())


### PR DESCRIPTION
- [REF] broken_module: Fix False expression, now is required a string
- [REF] flake8 rc: 'Skip F999 dictionary key 'name' repeated with different values' because pylint support this check
- [REF] test_server: Fix flake8