### PR TITLE
Allow tested directory to contain addon dirs

### DIFF
--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -129,9 +129,9 @@ def get_addons_path(travis_dependencies_dir, travis_build_dir, server_path):
     :param server_path: Server path
     :return: Addons path
     """
-    addons_path_list = get_addons(travis_dependencies_dir)
-    addons_path_list.insert(0, travis_build_dir)
-    addons_path_list.append(server_path + "/addons")
+    addons_path_list = get_addons(travis_build_dir)
+    addons_path_list.extend(get_addons(travis_dependencies_dir))
+    addons_path_list.append(os.path.join(server_path, "addons"))
     addons_path = ','.join(addons_path_list)
     return addons_path
 


### PR DESCRIPTION
Previously the tested directory ought to be an addons directory.
With this change, it can instead contain several addon directories.
A search will be done inside it,to find all contained addon directories,
and test will be run on all of them.

Intended to replace #382