### PR TITLE
[NEW] Build and deploy github sphinix project page

### DIFF
--- a/travis/travis_after_tests_success
+++ b/travis/travis_after_tests_success
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 
 import os
+import sys
+import subprocess
 
 from coverage.cmdline import main as coverage_main
 from coveralls import cli as coveralls_cli
 from codecov import main as codecov_main
 
+status = 0
 
 if (os.environ.get('TESTS', '1') == '1' and
         os.environ.get('TEST_ENABLE', '1') == '1' and
@@ -19,3 +22,12 @@ if (os.environ.get('TESTS', '1') == '1' and
         codecov_main(argv=None)
     except:
         pass
+
+if os.environ.get('DOC') == '1':
+    odoo_version = os.environ.get("VERSION")
+    status += subprocess.call(['travis-sphinx',
+                               '--branch=%s' % odoo_version,
+                               'deploy'
+                               ])
+
+sys.exit(0 if status == 0 else 1)

--- a/travis/travis_doc_build
+++ b/travis/travis_doc_build
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+import os
+import subprocess
+import sys
+
+from getaddons import get_modules
+
+
+root_dir = os.path.dirname(os.path.abspath(__file__))
+status = 0
+
+for addon in get_modules(os.path.abspath('.')):
+    status += subprocess.call(['sphinx-apidoc',
+                               '-f',
+                               '-o',
+                               'docs/source/addons/%s' % addon,
+                               addon])
+status += subprocess.call(['travis-sphinx', '-n', 'build'])
+
+sys.exit(0 if status == 0 else 1)

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -14,6 +14,14 @@ if [ "${LINT_CHECK}" != "0" ]; then
     exit 0
 fi
 
+if [ "${DOC}" != "0" ]; then
+    pip install --upgrade sphinx sphinx-rtd-theme sphinx_bootstrap_theme odoo-sphinx-autodoc
+    pip install --upgrade docutils
+    pip install --upgrade pillow
+    pip install --upgrade --user travis-sphinx
+    export PATH=$HOME/.local/bin:$PATH
+fi
+
 # We can exit here and do nothing if this only a LINT check
 if [ "${TESTS}" != "1" ] && [ "${LINT_CHECK}" == "1" ]; then
     exit 0

--- a/travis/travis_run_tests
+++ b/travis/travis_run_tests
@@ -56,6 +56,7 @@ if __name__ == '__main__':
     is_oca_project = os.environ.get('TRAVIS_REPO_SLUG', '').startswith('OCA/')
     is_oca_transifex_user = os.environ.get('TRANSIFEX_USER') == \
         'transbot@odoo-community.org'
+    doc_enabled = os.environ.get('DOC') == '1'
 
     # TRAVIS_PULL_REQUEST contains the pull request number or 'false'
     is_pull_request = os.environ.get('TRAVIS_PULL_REQUEST') != 'false'
@@ -78,6 +79,9 @@ if __name__ == '__main__':
 
     if transifex_enabled and is_valid_transifex:
         tests.append(['travis_transifex.py'])
+
+    if doc_enabled:
+        tests.append(['travis_doc_build'])
 
     if tests:
         exit(main(tests))


### PR DESCRIPTION
Hi,

With this feature we can automatic deploy module doc to a sphinix github page:

- autodoc will create module docs automaticaly from docstring;
- when merged to destination branch, the new version of the documentation is pushed to the branch gh-pages;

Job Example: https://travis-ci.org/kmee/l10n-brazil/jobs/181258185
Website example: http://www.odoobrasil.com.br/
Autodoc example: http://www.odoobrasil.com.br/py-modindex.html

Future roadmap:
- Multiple project versions ( v8, v9, v10)
- Sphinx + robot framework = documentation as result of functional testing:
  - https://travis-ci.org/kmee/odoo-travis-robotframework#L2668 
  - https://github.com/kmee/odoo-travis-robotframework/blob/master/docs/source/sale/index.rst.txt