### PR TITLE
[IMP] Switch git clone for archive download in depends download

### DIFF
--- a/travis/clone_oca_dependencies
+++ b/travis/clone_oca_dependencies
@@ -56,14 +56,14 @@ def parse_depfile(depfile, owner='OCA'):
 
 def git_checkout(deps_checkout_dir, reponame, url, branch):
     checkout_dir = osp.join(deps_checkout_dir, reponame)
-    if not osp.isdir(checkout_dir):
-        command = ['git', 'clone', '-q', url, '-b', branch, checkout_dir]
-    else:
-        command = ['git', '--git-dir=' + os.path.join(checkout_dir, '.git'),
-                   '--work-tree=' + checkout_dir, 'pull', '--ff-only',
-                   url, branch]
+    uri = "https://github.com/%s/archive/%s.tar.gz" % (
+        reponame, branch,
+    )
+    command = 'curl -sL %s | tar -xz -C %s' % (
+        uri, checkout_dir,
+    )
     _logger.info('Calling %s', ' '.join(command))
-    subprocess.check_call(command)
+    subprocess.check_call(command, shell=True)
     return checkout_dir
 
 

--- a/travis/clone_oca_dependencies
+++ b/travis/clone_oca_dependencies
@@ -56,14 +56,15 @@ def parse_depfile(depfile, owner='OCA'):
 
 def git_checkout(deps_checkout_dir, reponame, url, branch):
     checkout_dir = osp.join(deps_checkout_dir, reponame)
-    uri = "https://github.com/%s/archive/%s.tar.gz" % (
-        reponame, branch,
-    )
-    command = 'curl -sL %s | tar -xz -C %s' % (
-        uri, checkout_dir,
-    )
+    if not osp.isdir(checkout_dir):
+        command = ['git', 'clone', '-q', url, '-b', branch,
+                   '--single-branch', '--depth=1', checkout_dir]
+    else:
+        command = ['git', '--git-dir=' + os.path.join(checkout_dir, '.git'),
+                   '--work-tree=' + checkout_dir, 'pull', '--ff-only',
+                   url, branch]
     _logger.info('Calling %s', ' '.join(command))
-    subprocess.check_call(command, shell=True)
+    subprocess.check_call(command)
     return checkout_dir
 
 


### PR DESCRIPTION
I was messing around in LasLabs/docker-odoo#1 & realized that an easy way for us to get a pretty good speed boost on our builds is to use Github archives instead of cloning the repo.

Is there a specific reason we are cloning here? Are these archives not always current or something? I tested a bit and they seem to be current.

I'm not proposing this code in its current form, but something very close. Any thoughts?