### PR TITLE
[FIX] set pillow version in travis requirements, version 8.0 PR are failling

### DIFF
--- a/travis/requirements.txt
+++ b/travis/requirements.txt
@@ -11,7 +11,7 @@ Jinja2
 mako
 mock
 passlib
-pillow
+pillow == 3.4.2
 polib
 psutil
 psycopg2 >= 2.2


### PR DESCRIPTION
take a look to https://github.com/OCA/sale-workflow/pull/388