### PR TITLE
[FIX] Fix Python shebangs to use env

### DIFF
--- a/tests/test_repo/broken_module/__init__.py
+++ b/tests/test_repo/broken_module/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: latin-1 -*-
 from . import model
 from . import interpreter_wox

--- a/tests/test_repo/broken_module/interpreter_wox.py
+++ b/tests/test_repo/broken_module/interpreter_wox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 

--- a/tests/test_repo/broken_uninstallable/__init__.py
+++ b/tests/test_repo/broken_uninstallable/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: latin-1 -*-
 from . import model
 from . import interpreter_wox

--- a/tests/test_repo/broken_uninstallable/interpreter_wox.py
+++ b/tests/test_repo/broken_uninstallable/interpreter_wox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 

--- a/travis/clone_oca_dependencies
+++ b/travis/clone_oca_dependencies
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """Usage: clone_oca_dependencies [<checkout_dir> <build_dir>]
 
 Arguments:


### PR DESCRIPTION
`clone_oca_dependencies` is breaking some things for me due to the shebang being to a direct python. 

Went ahead and changed all of the instances of `#!/usr/bin/python` to `#!/usr/bin/env python`