### PR TITLE
[ADD] Codecov to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 simplejson
 pyserial
 pyyaml
+codecov
 coveralls


### PR DESCRIPTION
Simple one - we're using [codecov](https://github.com/OCA/maintainer-quality-tools/blob/e86286bdf325b61188ca25f1b14f8211e4f6bc89/travis/travis_after_tests_success#L7), but it's not in the requirements file.