### PR TITLE
Fix master version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,30 +23,30 @@ virtualenv:
 env:
 
   global:
-  - VERSION="9.0" TESTS="1" LINT_CHECK="0"
+  - BRANCH="9.0" TESTS="1" LINT_CHECK="0"
 
   matrix:
   - INSTANCE_ALIVE="1" INCLUDE="broken_module" SERVER_EXPECTED_ERRORS="2"  # test errors are detected
   - EXCLUDE="broken_module,broken_lint,broken_no_access_rule" OPTIONS="--log-level=debug" INSTALL_OPTIONS="--log-level=info" RUN_COMMAND_MQT_CREATE_FOLDER='mkdir /tmp/tests'
   - INCLUDE="test_module,second_module" UNIT_TEST="1"
-  - VERSION="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # ODOO_REPO usage example
-  - VERSION="6.1" INCLUDE="test_module,second_module"
+  - BRANCH="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # ODOO_REPO usage example
+  - BRANCH="6.1" INCLUDE="test_module,second_module"
   - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="21" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
-  - VERSION=master EXCLUDE="broken_no_access_rule" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="26" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
-  - VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="24" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
-  - VERSION="" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="21" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
+  - BRANCH=master EXCLUDE="broken_no_access_rule" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="26" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
+  - BRANCH="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="24" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
+  - BRANCH="" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="21" TRAVIS_PULL_REQUEST="false"  # To check BRANCH empty or unset case.
   - INCLUDE="broken_no_access_rule" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
 
 install:
   - cp -r ../maintainer-quality-tools/ $HOME
   - cp -r tests/test_repo/* ./
   - export PATH=$HOME/maintainer-quality-tools/travis:$PATH
-  - travis_install_nightly 8.0 # only used if VERSION not set in env
+  - travis_install_nightly 8.0 # only used if BRANCH not set in env
   - pip install coveralls  # Force install coveralls in all cases of MQT for self_test script.
   - git --git-dir=${TRAVIS_BUILD_DIR}/.git add --all  # All modules moved are modules changed to test PR changes
 
 script:
-  - coverage run --append ./travis/travis_run_tests 8.0  # only used if VERSION not set in env
+  - coverage run --append ./travis/travis_run_tests 8.0  # only used if BRANCH not set in env
   - coverage run --append ./travis/self_tests
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This is activated through the `UNIT_TEST` directive.
 For current repositories to benefit this, an additional line should be added to the `env:` section,
 similar to this one:
 
-    - VERSION="8.0" UNIT_TEST="1"
+    - BRANCH="8.0" UNIT_TEST="1"
 
 
 Coveralls configuration file
@@ -49,7 +49,7 @@ Isolated pylint+flake8 checks
 If you want to make a build exclusive for these checks, you can add a line
 on the `env:` section of the .travis.yml file with this content:
 
-    - VERSION="7.0" LINT_CHECK="1"
+    - BRANCH="7.0" LINT_CHECK="1"
 
 You will get a faster answer about these questions and also a fast view over
 semaphore icons in Travis build view.
@@ -57,7 +57,7 @@ semaphore icons in Travis build view.
 To avoid making again these checks on other builds, you have to add
 LINT_CHECK="0" variable on the line:
 
-    - VERSION="7.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
+    - BRANCH="7.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
 
 
 Disable test

--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -32,7 +32,7 @@ addons:
 
 env:
   global:
-  - VERSION="8.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
+  - BRANCH="8.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
   - TRANSIFEX_USER='transbot@odoo-community.org'
   # This line contains the encrypted transifex password
   # To encrypt transifex password, install travis ruby utils with:
@@ -42,7 +42,7 @@ env:
   # Secure list for current OCA projects is in https://github.com/OCA/maintainer-quality-tools/issues/194
   - secure: PjP88tPSwimBv4tsgn3UcQAD1heK/wcuSaSfhi2xUt/jSrOaTmWzjaW2gH/eKM1ilxPXwlPGyAIShJ2JJdBiA97hQufOeiqxdkWDctnNVVEDx2Tk0BiG3PPYyhXPgUZ+FNOnjZFF3pNWvzXTQaB0Nvz8plqp93Ov/DEyhrCxHDs=
   # Use the following lines if you need to manually change the transifex project slug or/and the transifex organization.
-  # The default project slug is owner-repo_name-version (with dash in the version string).
+  # The default project slug is owner-repo_name-branch (with dash in the branch string instead of ".").
   # The default organization is the owner of the repo.
   # The default fill up resources (TM) is True.
   # The default team is 23907. https://www.transifex.com/organization/oca/team/23907/

--- a/travis/clone_oca_dependencies
+++ b/travis/clone_oca_dependencies
@@ -21,7 +21,7 @@ The expected format for oca_dependencies.txt:
 * a dependency line contains:
   - the name of the OCA project
   - (optional) the URL to the git repository (defaulting to the OCA repository)
-  - (optional) the name of the branch to use (defaulting to ${VERSION})
+  - (optional) the name of the branch to use (defaulting to ${BRANCH})
 """
 from __future__ import print_function
 import sys
@@ -45,7 +45,7 @@ def parse_depfile(depfile, owner='OCA'):
         if len(parts) > 2:
             branch = parts[2]
         else:
-            branch = os.environ.get('VERSION', '8.0')
+            branch = os.environ.get('BRANCH', '8.0')
         if len(parts) > 1:
             url = parts[1]
         else:

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -7,7 +7,7 @@ Use the following types of pylint configuration files:
 
  1) Global
  2) Pull request
- 3) Version
+ 3) Branch
  4) Beta
 
 
@@ -26,11 +26,11 @@ Use the following types of pylint configuration files:
   File name: `travis_run_pylint_pr.cfg`
 
 
-2) Version Exclusions
+2) Branch Exclusions
 
   Used to disable the previously enabled messages of `global` or `pull request`
-  configuration files based on `VERSION` variable environment.
-  File name: `travis_run_pylint_exclude_{VERSION}.cfg`
+  configuration files based on `BRANCH` variable environment.
+  File name: `travis_run_pylint_exclude_{BRANCH}.cfg`
 
 
 3) Beta
@@ -54,12 +54,12 @@ from getaddons import get_modules_changed
 from git_run import GitRun
 
 
-def get_extra_params(odoo_version):
-    '''Get extra pylint params by odoo version
+def get_extra_params(branch):
+    '''Get extra pylint params by odoo branch
     Transform a seudo-pylint-conf to params,
     it to overwrite base-pylint-conf values.
     Use a seudo-inherit of configuration file.
-    To avoid have a 2 config files (stable and pr-conf) by each odoo-version
+    To avoid have a 2 config files (stable and pr-conf) by each odoo-branch
     Example:
 
         pylint_master.conf
@@ -72,9 +72,9 @@ def get_extra_params(odoo_version):
         pylint_70_pr.conf
         pylint_61.conf
         pylint_61_pr.conf
-        ... and new future versions.
+        ... and new future branchs.
 
-    If you need add a new conventions in all versions
+    If you need add a new conventions in all branchs
     you will need change all pr files or stables files.
 
 
@@ -85,21 +85,21 @@ def get_extra_params(odoo_version):
         pylint_disabling_70.conf <- Overwrite params of pylint_lastest*.conf
         pylint_disabling_61.conf <- Overwrite params of pylint_lastest*.conf
 
-    If you need add a new conventions in all versions you will need change just
+    If you need add a new conventions in all branchs you will need change just
     pylint_lastest_pr.conf or pylint_lastest.conf, similar to inherit.
 
-    :param version: String with name of version of odoo
+    :param branch: String with name of branch of odoo
     :return: List of extra pylint params
     '''
-    odoo_version = odoo_version.replace('.', '')
-    version_cfg = os.path.join(
+    branch = branch.replace('.', '')
+    branch_cfg = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
-        'cfg/travis_run_pylint_exclude_{odoo_version}.cfg'.format(
-            odoo_version=odoo_version))
+        'cfg/travis_run_pylint_exclude_{branch}.cfg'.format(
+            branch=branch))
     params = []
-    if os.path.isfile(version_cfg):
+    if os.path.isfile(branch_cfg):
         config = ConfigParser.ConfigParser()
-        config.readfp(open(version_cfg))
+        config.readfp(open(branch_cfg))
         for section in config.sections():
             for option, value in config.items(section):
                 params.extend(['--' + option, value])
@@ -131,29 +131,29 @@ def get_beta_msgs():
         for msg in config.get('MESSAGES CONTROL', 'enabled2beta').split(',')
         if msg.strip()]
 
-version = os.environ.get('VERSION', False)
+branch = os.environ.get('BRANCH', False)
 
-if not version:
+if not branch:
     if git_work_dir:
         repo_path = os.path.join(git_work_dir, '.git')
         branch_name = GitRun(repo_path).get_branch_name()
-        version = branch_name.replace('_', '-').split('-')[:1] \
+        branch = branch_name.replace('_', '-').split('-')[:1] \
             if branch_name else False
-        version = version[0] if version and len(version) else None
+        branch = branch[0] if branch and len(branch) else None
 
-if version:
-    extra_params = get_extra_params(version)
+if branch:
+    extra_params = get_extra_params(branch)
     for extra_param in extra_params:
         extra_params_cmd.extend([
             '--extra-params', extra_param
         ])
-    is_version_number = re.match(r'\d+\.\d+', version)
-    if is_version_number:
+    is_branch_number = re.match(r'\d+\.\d+', branch)
+    if is_branch_number:
         extra_params_cmd.extend([
-            '--extra-params', '--valid_odoo_versions=%s' % version])
+            '--extra-params', '--valid_branches=%s' % branch])
 else:
-    print(travis_helpers.yellow('Undefined environment variable `VERSION`.'
-          '\nSet `VERSION` for compatibility with guidelines by version.'))
+    print(travis_helpers.yellow('Undefined environment variable `BRANCH`.'
+          '\nSet `BRANCH` for compatibility with guidelines by branch.'))
 
 
 beta_msgs = get_beta_msgs()

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -150,7 +150,7 @@ if branch:
     is_branch_number = re.match(r'\d+\.\d+', branch)
     if is_branch_number:
         extra_params_cmd.extend([
-            '--extra-params', '--valid_branches=%s' % branch])
+            '--extra-params', '--valid_versions=%s' % branch])
 else:
     print(travis_helpers.yellow('Undefined environment variable `BRANCH`.'
           '\nSet `BRANCH` for compatibility with guidelines by branch.'))

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -111,7 +111,7 @@ def get_server_path(odoo_full, branch, travis_home):
     """
     Calculate server path
     :param odoo_full: Odoo repository path
-    :param branch: Odoo version
+    :param branch: Odoo branch
     :param travis_home: Travis home directory
     :return: Server path
     """
@@ -233,7 +233,7 @@ def run_from_env_var(env_name_startswith, environ):
         subprocess.call(command, shell=True)
 
 
-def create_server_conf(data, version):
+def create_server_conf(data):
     '''Create (or edit) default configuration file of odoo
     :params data: Dict with all info to save in file'''
     fname_conf = os.path.expanduser('~/.openerp_serverrc')
@@ -279,7 +279,7 @@ def main(argv=None):
     data_dir = os.environ.get("DATA_DIR", '~/data_dir')
     test_enable = str2bool(os.environ.get('TEST_ENABLE', True))
     if not branch:
-        # For backward compatibility, take version from parameter
+        # For backward compatibility, take branch from parameter
         # if it's not globally set
         branch = argv[1]
         print("WARNING: no env variable set for BRANCH. "
@@ -310,7 +310,7 @@ def main(argv=None):
     create_server_conf({
         'addons_path': addons_path,
         'data_dir': data_dir,
-    }, branch)
+    })
     tested_addons_list = get_addons_to_check(travis_build_dir,
                                              odoo_include,
                                              odoo_exclude)

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -136,10 +136,6 @@ def get_addons_path(travis_dependencies_dir, travis_build_dir, server_path):
     return addons_path
 
 
-def get_server_script(odoo_version):
-    return 'odoo-bin' if float(odoo_version) >= 10 else 'openerp-server'
-
-
 def get_addons_to_check(travis_build_dir, odoo_include, odoo_exclude):
     """
     Get the list of modules that need to be installed
@@ -183,7 +179,7 @@ def get_test_dependencies(addons_path, addons_list):
                 set(addons_list))
 
 
-def setup_server(db, odoo_unittest, tested_addons, server_path, script_name,
+def setup_server(db, odoo_unittest, tested_addons, server_path,
                  addons_path, install_options, preinstall_modules=None,
                  unbuffer=True, server_options=None):
     """
@@ -210,7 +206,7 @@ def setup_server(db, odoo_unittest, tested_addons, server_path, script_name,
     else:
         # unbuffer keeps output colors
         cmd_odoo = ["unbuffer"] if unbuffer else []
-        cmd_odoo += ["%s/%s" % (server_path, script_name),
+        cmd_odoo += ["%s/openerp-server" % server_path,
                      "-d", db,
                      "--log-level=info",
                      "--stop-after-init",
@@ -302,7 +298,6 @@ def main(argv=None):
             test_loghandler = 'openerp.tools.yaml_import:DEBUG'
     odoo_full = os.environ.get("ODOO_REPO", "odoo/odoo")
     server_path = get_server_path(odoo_full, odoo_version, travis_home)
-    script_name = get_server_script(odoo_version)
     addons_path = get_addons_path(travis_dependencies_dir,
                                   travis_build_dir,
                                   server_path)
@@ -331,14 +326,14 @@ def main(argv=None):
         os.environ.get('TRAVIS_BUILD_DIR'))))
     print("Modules to preinstall: %s" % preinstall_modules)
     setup_server(dbtemplate, odoo_unittest, tested_addons, server_path,
-                 script_name, addons_path, install_options, preinstall_modules,
-                 unbuffer, server_options)
+                 addons_path, install_options, preinstall_modules, unbuffer,
+                 server_options)
 
     # Running tests
     database = "openerp_test"
 
     cmd_odoo_test = ["coverage", "run",
-                     "%s/%s" % (server_path, script_name),
+                     "%s/openerp-server" % server_path,
                      "-d", database,
                      "--stop-after-init",
                      "--log-level", test_loglevel,
@@ -350,12 +345,12 @@ def main(argv=None):
 
     if odoo_unittest:
         to_test_list = tested_addons_list
-        cmd_odoo_install = [
-            "%s/%s" % (server_path, script_name),
-            "-d", database,
-            "--stop-after-init",
-            "--log-level=warn",
-        ] + install_options + ["--init", None] + server_options
+        cmd_odoo_install = ["%s/openerp-server" % server_path,
+                            "-d", database,
+                            "--stop-after-init",
+                            "--log-level=warn",
+                            ] + install_options + ["--init", None] +\
+                            server_options
         commands = ((cmd_odoo_install, False),
                     (cmd_odoo_test, True),
                     )

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -298,6 +298,12 @@ def main(argv=None):
             test_loghandler = 'openerp.tools.yaml_import:DEBUG'
     odoo_full = os.environ.get("ODOO_REPO", "odoo/odoo")
     server_path = get_server_path(odoo_full, odoo_version, travis_home)
+    # Normalize on v10 odoo-bin command
+    try:
+      copy(os.path.join(server_path, 'openerp-server')), 
+           os.path.join(server_path, 'odoo-bin')))
+    except IOError:
+      pass
     addons_path = get_addons_path(travis_dependencies_dir,
                                   travis_build_dir,
                                   server_path)

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -25,17 +25,20 @@ ln -s `which nodejs` $HOME/maintainer-quality-tools/travis/node
 npm install -g less less-plugin-clean-css
 
 
-# For backward compatibility, take version from parameter if it's not globally set
-if [ "x${VERSION}" == "x" ] ; then
-    VERSION="${1}"
-    echo "WARNING: no env variable set for VERSION. Using '${1}'."
+# For backward compatibility, take branch from parameter if it's not globally set
+if [ "x${BRANCH}" == "x" ] ; then
+    if [ "x${VERSION}" == "x" ] ; then
+        export BRANCH="${1}"
+        echo "WARNING: no env variable set for BRANCH. Using '${1}'."
+    else:
+        export BRANCH="${VERSION}"
+        echo "WARNING: env variable VERSION is deprecated, use BRANCH instead."
 fi
 
 : ${ODOO_REPO:="odoo/odoo"}  # default value, if not set
 IFS="/" read -a REPO <<< "${ODOO_REPO}"
 export REMOTE="${REPO[0],,}"
 export REPO_NAME="${REPO[1]}"
-export BRANCH="${VERSION}"
 export ODOO_PATH=${HOME}/$REPO_NAME-$BRANCH
 if [ -z "${REPO_CACHED}"  ]; then
     export ODOO_URL="https://github.com/$REMOTE/$REPO_NAME/archive/$BRANCH.tar.gz"

--- a/travis/travis_transifex.py
+++ b/travis/travis_transifex.py
@@ -47,20 +47,20 @@ def main(argv=None):
     odoo_exclude = os.environ.get("EXCLUDE")
     odoo_include = os.environ.get("INCLUDE")
     install_options = os.environ.get("INSTALL_OPTIONS", "").split()
-    odoo_version = os.environ.get("VERSION")
+    branch = os.environ.get("BRANCH")
 
-    if not odoo_version:
+    if not branch:
         # For backward compatibility, take version from parameter
         # if it's not globally set
-        odoo_version = argv[1]
-        print(yellow_light("WARNING: no env variable set for VERSION. "
-              "Using '%s'" % odoo_version))
+        branch = argv[1]
+        print(yellow_light("WARNING: no env variable set for BRANCH. "
+              "Using '%s'" % branch))
 
     default_project_slug = "%s-%s" % (travis_repo_slug.replace('/', '-'),
-                                      odoo_version.replace('.', '-'))
+                                      branch.replace('.', '-'))
     transifex_project_slug = os.environ.get("TRANSIFEX_PROJECT_SLUG",
                                             default_project_slug)
-    transifex_project_name = "%s (%s)" % (travis_repo_shortname, odoo_version)
+    transifex_project_name = "%s (%s)" % (travis_repo_shortname, branch)
     transifex_organization = os.environ.get("TRANSIFEX_ORGANIZATION",
                                             travis_repo_owner)
     transifex_fill_up_resources = os.environ.get(
@@ -72,14 +72,14 @@ def main(argv=None):
     repository_url = "https://github.com/%s" % travis_repo_slug
 
     odoo_full = os.environ.get("ODOO_REPO", "odoo/odoo")
-    server_path = get_server_path(odoo_full, odoo_version, travis_home)
+    server_path = get_server_path(odoo_full, branch, travis_home)
     addons_path = get_addons_path(travis_dependencies_dir,
                                   travis_build_dir,
                                   server_path)
     addons_list = get_addons_to_check(travis_build_dir, odoo_include,
                                       odoo_exclude)
     addons = ','.join(addons_list)
-    create_server_conf({'addons_path': addons_path}, odoo_version)
+    create_server_conf({'addons_path': addons_path}, branch)
 
     print("\nWorking in %s" % travis_build_dir)
     print("Using repo %s and addons path %s" % (odoo_full, addons_path))
@@ -125,7 +125,7 @@ def main(argv=None):
 
     # Install the modules on the database
     database = "openerp_i18n"
-    script_name = get_server_script(odoo_version)
+    script_name = get_server_script(branch)
     setup_server(database, odoo_unittest, addons, server_path, script_name,
                  addons_path, install_options, addons_list)
 
@@ -139,7 +139,7 @@ def main(argv=None):
     path_to_tx = utils.find_dot_tx()
 
     # Use by default version 10 connection context
-    connection_context = context_mapping.get(odoo_version, Odoo10Context)
+    connection_context = context_mapping.get(branch, Odoo10Context)
     with connection_context(server_path, addons_path, database) \
             as odoo_context:
         for module in addons_list:


### PR DESCRIPTION
# replaces https://github.com/OCA/maintainer-quality-tools/pull/409 
Copied from https://github.com/OCA/maintainer-quality-tools/pull/409#issuecomment-271448719:

> if we want test a feature from master or saas-* valid branches from official repository(1) we can not use them since merge of #364
> 
> This PR add accidentally a new lock to use just branches name with valid version.
> Now the original author is agree with the change of this PR (2)
> 
> (1) https://github.com/odoo/odoo/branches/active
> (2) #398 (comment)