### PR TITLE
[IMP] better db inventory with flexible db names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
   - EXCLUDE="broken_module,broken_lint,broken_no_access_rule" OPTIONS="--log-level=debug" INSTALL_OPTIONS="--log-level=info" RUN_COMMAND_MQT_CREATE_FOLDER='mkdir /tmp/tests'
   - INCLUDE="test_module,second_module" UNIT_TEST="1"
   - VERSION="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # ODOO_REPO usage example
+  - TESTS="1" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB" MQT_TEMPLATE_DB='mqt_odoo_template_core' MQT_TEST_DB='mqt_odoo_core'
   - VERSION="6.1" INCLUDE="test_module,second_module"
   - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="21" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
   - VERSION=master EXCLUDE="broken_no_access_rule" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="26" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file

--- a/README.md
+++ b/README.md
@@ -1,36 +1,38 @@
 [![Build Status](https://travis-ci.org/OCA/maintainer-quality-tools.svg)](https://travis-ci.org/OCA/maintainer-quality-tools)
 [![Coverage Status](https://coveralls.io/repos/OCA/maintainer-quality-tools/badge.svg)](https://coveralls.io/r/OCA/maintainer-quality-tools)
 
-QA Tools for Odoo maintainers
-=============================
+QA Tools for Odoo maintainers (MQT)
+===================================
 
-The goal is to provide helpers to ensure the quality of Odoo addons.
+The goal of Maintainer Quality Tools (MQT) is to provide helpers to ensure the quality of Odoo addons.
 
 Sample travis configuration file (for version 7.0)
 --------------------------------------------------
 
-To setup the TravisCI continuous integration for your project, just copy the
+In order to setup TravisCI continuous integration for your project, just copy the
 content of the [`/sample_files`](https://github.com/OCA/maintainer-quality-tools/tree/master/sample_files)
 to your project’s root directory.
 
-If your project depends on other OCA/Github repositories, create a file called `oca_dependencies.txt` at the root of your project and list the dependencies in there, one per line:
+If your project depends on other OCA or other Github repositories, create a file called `oca_dependencies.txt` at the root of your project and list the dependencies there. One per line like so:
 
     project_name optional_repository_url optional_branch_name
 
-The addons path used will automatically consider these repositories.
+During testbed setup, MQT will automatically download and place these repositories accordingly into the addon path.
+Note on addons path ordering: They will be placed after your own repo, but before the odoo core repo.
 
 Check your .travis file for syntax issues.
 ------------------------------------------
 
-You can test your .travis file in [this linter](http://lint.travis-ci.org/) very useful when you are improving your file.
+You can test your .travis file in [this linter](http://lint.travis-ci.org/).
+This is very useful when you are improving your file.
 
 Module unit tests
 -----------------
 
-The quality tools now are also capable to test each module individually.
-This is intended to check if all dependencies are correctly defined.
-This is activated through the `UNIT_TEST` directive.
-For current repositories to benefit this, an additional line should be added to the `env:` section,
+MQT is also capable to test each module individually.
+The intention is to check if all dependencies are correctly defined.
+Activate it through the `UNIT_TEST` directive.
+An additional line should be added to the `env:` section,
 similar to this one:
 
     - VERSION="8.0" UNIT_TEST="1"
@@ -44,8 +46,8 @@ Currently the Coveralls configuration is automatic, so you don't need to include
 to the repository. Please note that if you do it, it will be ignored.
 
 
-Naming of testing DBs
----------------------
+Names used for the test databases
+---------------------------------
 
 MQT has a nice feature of organizing your testing databases.
 You might want to do that if you want to double them up as 
@@ -75,7 +77,8 @@ LINT_CHECK="0" variable on the line:
 
 Disable test
 ------------
-If you want to make a build without tests, you can add use the environment variable:
+If you want to make a build without tests, you can use the following directive:
 `TEST_ENABLE="0"`
 
-You will get the databases with packages installed but without run test.
+You will simply get the databases with packages installed, 
+but whithout running any tests.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ Currently the Coveralls configuration is automatic, so you don't need to include
 to the repository. Please note that if you do it, it will be ignored.
 
 
+Naming of testing DBs
+---------------------
+
+MQT has a nice feature of organizing your testing databases.
+You might want to do that if you want to double them up as 
+staging DBs or if you want to work with an advanced set of
+templates in order to speed up your CI pipeline.
+Just specify at will:
+`MQT_TEMPLATE_DB='mqt_odoo_template' MQT_TEST_DB='mqt_odoo_test'`.
+Give us feedback on you experiences, and if you could share findings
+from your use case, there might be some grateful people arround.
+
+
 Isolated pylint+flake8 checks
 -----------------------------
 If you want to make a build exclusive for these checks, you can add a line

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -282,6 +282,8 @@ def main(argv=None):
     unbuffer = str2bool(os.environ.get('UNBUFFER', True))
     data_dir = os.environ.get("DATA_DIR", '~/data_dir')
     test_enable = str2bool(os.environ.get('TEST_ENABLE', True))
+    dbtemplate = os.environ.get('MQT_TEMPLATE_DB', 'openerp_template')
+    database = os.environ.get('MQT_TEST_DB', 'openerp_test')
     if not odoo_version:
         # For backward compatibility, take version from parameter
         # if it's not globally set
@@ -324,7 +326,6 @@ def main(argv=None):
     else:
         print("Modules to test: %s" % tested_addons)
     # setup the base module without running the tests
-    dbtemplate = "openerp_template"
     preinstall_modules = get_test_dependencies(addons_path,
                                                tested_addons_list)
     preinstall_modules = list(set(preinstall_modules) - set(get_modules(
@@ -335,8 +336,6 @@ def main(argv=None):
                  unbuffer, server_options)
 
     # Running tests
-    database = "openerp_test"
-
     cmd_odoo_test = ["coverage", "run",
                      "%s/%s" % (server_path, script_name),
                      "-d", database,


### PR DESCRIPTION
**What I did**

_Before:_ Hard coded db names (template and actual db)
_After:_ Default to same hard coded names, if no environment variable is present.

**Why I did it**
- Having an external postgres service holding the databases,
- I want to be able to organize and reuse my build db inventory,
- in order to shorten test cycles and reuse built databases for staging instances

**I already know the questions...**
- Yes, It's easy to share filestore. I have thought of that. Eg. with docker volumes.
- Yes, there is runbot, but with those two changes, I save a lot of work by not having to setup and include another, somewhat bulky, infrastructure stack. Hey, my time is valuable, too :)
- No, it's not reinventing the wheel. There are just red and green tires available. You don't want green tires on a blue car. Ok, after all that's personal preferences, right? 🍻 
- Yes, I'm interested in helping get MQT a broader use base without unduly compromising it's focus and main use case.
- Yes, I chose environment variables to stick to the common practice to prepend them with its use. However, maybe `MQT_DB_TEMPLATE_NAME` and `MQT_DB_TEST_NAME` would be more in line, looking at this piece of delicious code (MQT) from an outside perspective.