### PR TITLE
[IMP] Support branches in the environment variable VERSION of .travis.yml 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ You can use branch or pull request into environment variable VERSION:
     VERSION="pull/143" ODOO_REPO="odoo/odoo"
 ```
 
+Using custom branch inside odoo repository using ODOO_BRANCH
+------------------------------------------------------------
+
+You can use the custom branch into the ODOO_REPO using the environment variable ODOO_BRANCH:
+
+
+- Branch saas-17
+```
+  ODOO_REPO="odoo/odoo" ODOO_BRANCH="saas-17"
+```
+
 Module unit tests
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ Check your .travis file for syntax issues.
 
 You can test your .travis file in [this linter](http://lint.travis-ci.org/) very useful when you are improving your file.
 
+Multiple values for environment variable VERSION
+------------------------------------------------
+
+You can use branch or pull request into environment variable VERSION:
+
+- Branch 10.0
+```
+    VERSION="10.0" ODOO_REPO="odoo/odoo"
+```
+
+- Pull request odoo/odoo#143
+```
+    VERSION="pull/143" ODOO_REPO="odoo/odoo"
+```
+
 Module unit tests
 -----------------
 

--- a/travis/self_tests
+++ b/travis/self_tests
@@ -82,7 +82,7 @@ if os.environ.get('LINT_CHECK', 0) == '1':
 getaddons.get_modules_changed(repo_dir)
 
 # Testing get_server_script
-assert get_server_script("/tmp") == 'odoo-bin'
+assert get_server_script("/tmp") == 'openerp-server'
 
 # Testing instance running
 def connection_test():

--- a/travis/self_tests
+++ b/travis/self_tests
@@ -10,6 +10,7 @@ import getaddons
 import travis_helpers
 from test_server import main as test_server_main
 from test_server import get_test_dependencies
+from test_server import get_server_script
 
 repo_dir = os.environ.get("TRAVIS_BUILD_DIR", "./tests/test_repo/")
 exclude = os.environ.get("EXCLUDE")
@@ -80,6 +81,8 @@ if os.environ.get('LINT_CHECK', 0) == '1':
 # Testing git run from getaddons
 getaddons.get_modules_changed(repo_dir)
 
+# Testing get_server_script
+assert get_server_script("/tmp") == 'odoo-bin'
 
 # Testing instance running
 def connection_test():

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -284,6 +284,7 @@ def main(argv=None):
     server_options = os.environ.get('SERVER_OPTIONS', "").split()
     expected_errors = int(os.environ.get("SERVER_EXPECTED_ERRORS", "0"))
     odoo_version = os.environ.get("VERSION")
+    odoo_branch = os.environ.get("ODOO_BRANCH")
     instance_alive = str2bool(os.environ.get('INSTANCE_ALIVE'))
     unbuffer = str2bool(os.environ.get('UNBUFFER', True))
     data_dir = os.environ.get("DATA_DIR", '~/data_dir')
@@ -307,7 +308,8 @@ def main(argv=None):
             test_loglevel = 'info'
             test_loghandler = 'openerp.tools.yaml_import:DEBUG'
     odoo_full = os.environ.get("ODOO_REPO", "odoo/odoo")
-    server_path = get_server_path(odoo_full, odoo_version, travis_home)
+    server_path = get_server_path(odoo_full, odoo_branch or odoo_version,
+                                  travis_home)
     script_name = get_server_script(server_path)
     addons_path = get_addons_path(travis_dependencies_dir,
                                   travis_build_dir,

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -115,6 +115,7 @@ def get_server_path(odoo_full, odoo_version, travis_home):
     :param travis_home: Travis home directory
     :return: Server path
     """
+    odoo_version = odoo_version.replace('/', '-')
     odoo_org, odoo_repo = odoo_full.split('/')
     server_dirname = "%s-%s" % (odoo_repo, odoo_version)
     server_path = os.path.join(travis_home, server_dirname)
@@ -136,8 +137,13 @@ def get_addons_path(travis_dependencies_dir, travis_build_dir, server_path):
     return addons_path
 
 
-def get_server_script(odoo_version):
-    return 'odoo-bin' if float(odoo_version) >= 10 else 'openerp-server'
+def get_server_script(server_path):
+    try:
+        shutil.copy(os.path.join(server_path, 'openerp-server'),
+                    os.path.join(server_path, 'odoo-bin'))
+    except IOError:
+        pass
+    return 'odoo-bin'
 
 
 def get_addons_to_check(travis_build_dir, odoo_include, odoo_exclude):
@@ -302,7 +308,7 @@ def main(argv=None):
             test_loghandler = 'openerp.tools.yaml_import:DEBUG'
     odoo_full = os.environ.get("ODOO_REPO", "odoo/odoo")
     server_path = get_server_path(odoo_full, odoo_version, travis_home)
-    script_name = get_server_script(odoo_version)
+    script_name = get_server_script(server_path)
     addons_path = get_addons_path(travis_dependencies_dir,
                                   travis_build_dir,
                                   server_path)

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -138,12 +138,9 @@ def get_addons_path(travis_dependencies_dir, travis_build_dir, server_path):
 
 
 def get_server_script(server_path):
-    try:
-        shutil.copy(os.path.join(server_path, 'openerp-server'),
-                    os.path.join(server_path, 'odoo-bin'))
-    except IOError:
-        pass
-    return 'odoo-bin'
+    if os.path.isfile(os.path.join(server_path, 'odoo-bin')):
+        return 'odoo-bin'
+    return 'openerp-server'
 
 
 def get_addons_to_check(travis_build_dir, odoo_include, odoo_exclude):

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -31,18 +31,22 @@ if [ "x${VERSION}" == "x" ] ; then
     echo "WARNING: no env variable set for VERSION. Using '${1}'."
 fi
 
+if [ "x${ODOO_BRANCH}" == "x"  ] ; then
+    ODOO_BRANCH=${VERSION}
+fi
+
 : ${ODOO_REPO:="odoo/odoo"}  # default value, if not set
 IFS="/" read -a REPO <<< "${ODOO_REPO}"
 export REMOTE="${REPO[0],,}"
 export REPO_NAME="${REPO[1]}"
-export BRANCH="${VERSION}"
+export BRANCH="${ODOO_BRANCH}"
 export PULL_REQUEST=''
 # If the branch is a pull request
 if [[ $BRANCH == *"/"*  ]]; then
     export PULL_REQUEST=$BRANCH
     export BRANCH=${BRANCH/\//-}
 fi
-export ODOO_PATH=${HOME}/$REPO_NAME-$BRANCH
+export ODOO_PATH=${HOME}/$REPO_NAME-$ODOO_BRANCH
 if [ -z "${REPO_CACHED}"  ]; then
     export ODOO_URL="https://github.com/$REMOTE/$REPO_NAME/archive/$BRANCH.tar.gz"
     echo "Installing Odoo $ODOO_URL"

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -36,6 +36,12 @@ IFS="/" read -a REPO <<< "${ODOO_REPO}"
 export REMOTE="${REPO[0],,}"
 export REPO_NAME="${REPO[1]}"
 export BRANCH="${VERSION}"
+export PULL_REQUEST=''
+# If the branch is a pull request
+if [[ $BRANCH == *"/"*  ]]; then
+    export PULL_REQUEST=$BRANCH
+    export BRANCH=${BRANCH/\//-}
+fi
 export ODOO_PATH=${HOME}/$REPO_NAME-$BRANCH
 if [ -z "${REPO_CACHED}"  ]; then
     export ODOO_URL="https://github.com/$REMOTE/$REPO_NAME/archive/$BRANCH.tar.gz"
@@ -46,10 +52,19 @@ else
     echo "Using Odoo from cache ${REPO_CACHED}"
     chown `(whoami)`:`(id -gn)` -R ${REPO_CACHED}
     ln -sf ${REPO_CACHED}/odoo ${ODOO_PATH}
-    cd ${ODOO_PATH} \
-        && git fetch --depth=1 ${REMOTE} ${BRANCH} \
-        && git config --local --bool core.bare false \
-        && git checkout -b ${BRANCH}-${REMOTE} -qf ${REMOTE}/${BRANCH}
+    cd ${ODOO_PATH}
+    if [ "x${PULL_REQUEST}" == "x" ] ; then 
+        git fetch --depth=1 ${REMOTE} ${BRANCH} \
+            && git config --local --bool core.bare false \
+            && git checkout -b ${BRANCH}-${REMOTE} -qf ${REMOTE}/${BRANCH}
+    else
+        ODOO_URL="https://github.com/${ODOO_REPO}"
+        # Is a pull request
+        git reset --hard
+        git fetch --depth=1 ${REMOTE} $PULL_REQUEST/head:${BRANCH}-${REMOTE} \
+            && git config --local --bool core.bare false \
+            && git checkout ${BRANCH}-${REMOTE}
+    fi
 fi
 
 # Workaround to force using system site packages (see https://github.com/Shippable/support/issues/241#issuecomment-57947925)


### PR DESCRIPTION
Support branches in the environment variable VERSION of .travis.yml

Now
```
VERSION=master
ODOO_REPO=odoo/odoo
```
Expected
```
VERSION=pull/3
ODOO_REPO=odoo/odoo
```

In the enviroment variable `VERSION` can be used:
- [x] Branch : VERSION="master"
- [x] PR : VERSION="pull/10

Referring to issue #173 