### PR TITLE
Ignore *_example packages in coverage check

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Coveralls configuration file
 ----------------------------
 
 Coveralls provides information on the test coverage of your modules.
-Currently the Coveralls configuration is automatic (check default configuration [here]('cfg/.coveragerc')).
+Currently the Coveralls configuration is automatic (check default configuration [here](cfg/.coveragerc)).
 So, as of today, you don't need to include a `.coveragerc` into the repository,
 If you do it, it will be simply ignored.
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ Coveralls configuration file
 ----------------------------
 
 Coveralls provides information on the test coverage of your modules.
-Currently the Coveralls configuration is automatic, so you don't need to include a `.coveragerc`
-to the repository. Please note that if you do it, it will be ignored.
+Currently the Coveralls configuration is automatic (check default configuration [here]('cfg/.coveragerc')).
+So, as of today, you don't need to include a `.coveragerc` into the repository,
+If you do it, it will be simply ignored.
 
+**NOTE:** the current configuration automatically ignores `*_example` modules
+from coverage check.
+See [maintainer-tools CONTRIBUTING doc](https://github.com/OCA/maintainer-tools/blob/master/CONTRIBUTING.md#tests) for further info on tests.
 
 Names used for the test databases
 ---------------------------------

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ similar to this one:
     - VERSION="8.0" UNIT_TEST="1"
 
 
-Coveralls configuration file
-----------------------------
+Coveralls/Codecov configuration file
+------------------------------------
 
-Coveralls provides information on the test coverage of your modules.
-Currently the Coveralls configuration is automatic (check default configuration [here](cfg/.coveragerc)).
+[Coveralls](https://coveralls.io/) and [Codecov](https://codecov.io/) services provide information on the test coverage of your modules.
+Currently both configurations are automatic (check default configuration [here](cfg/.coveragerc)).
 So, as of today, you don't need to include a `.coveragerc` into the repository,
 If you do it, it will be simply ignored.
 

--- a/cfg/.coveragerc
+++ b/cfg/.coveragerc
@@ -9,6 +9,7 @@ omit =
     */scenarios/*
     */test/*
     */tests/*
+    *_example/*
     *__init__.py
     *__openerp__.py
     *__manifest__.py


### PR DESCRIPTION
See https://github.com/OCA/website-cms/pull/9#pullrequestreview-22552007

@moylop260 alternatively we could consider looking up for custom `.coveragerc` in the repo. What do you think?