### PR TITLE
[REF] flake8.cfg: Flake8 renamed F999 -> F601

### DIFF
--- a/travis/cfg/travis_run_flake8.cfg
+++ b/travis/cfg/travis_run_flake8.cfg
@@ -2,6 +2,6 @@
 # E123,E133,E226,E241,E242 are ignored by default by pep8 and flake8
 # F811 is legal in odoo 8 when we implement 2 interfaces for a method
 # F999 pylint support this case with expected tests
-ignore = E123,E133,E226,E241,E242,F811,F999
+ignore = E123,E133,E226,E241,E242,F811,F601
 max-line-length = 79
 exclude = __unported__,__init__.py

--- a/travis/cfg/travis_run_flake8__init__.cfg
+++ b/travis/cfg/travis_run_flake8__init__.cfg
@@ -2,7 +2,7 @@
 # E123,E133,E226,E241,E242 are ignored by default by pep8 and flake8
 # F401 is legal in odoo __init__.py files
 # F999 pylint support this case with expected tests
-ignore = E123,E133,E226,E241,E242,F401,F999
+ignore = E123,E133,E226,E241,E242,F401,F601
 max-line-length = 79
 exclude = __unported__
 filename = __init__.py


### PR DESCRIPTION
The following check is emitted:
`broken_module/__openerp__.py:3:5: F601 dictionary key 'name' repeated with different values`

Because new version of flake8 changed the name of the check from F999 to F601

See the following video with the evidence of the case:
[![IMAGE ALT TEXT](http://img.youtube.com/vi/DbfrGHpcaiw/0.jpg)](http://www.youtube.com/watch?v=DbfrGHpcaiw "Video Title")

Previously PR using F999
https://github.com/OCA/maintainer-quality-tools/pull/390