### PR TITLE
[FIX] Update PhantomJS

### DIFF
--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -33,6 +33,10 @@ addons:
 env:
   global:
   - VERSION="8.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
+  - PHANTOMJS_VERSION="latest"
+  # The above line controls the PhantomJS version that is used for JS testing.
+  #   It is not necessary to include this value unless you are altering the default.
+  #   Use `OS` to skip the PhantomJS upgrade & use the system version instead.
   - TRANSIFEX_USER='transbot@odoo-community.org'
   # This line contains the encrypted transifex password
   # To encrypt transifex password, install travis ruby utils with:

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -33,8 +33,7 @@ npm install -g less less-plugin-clean-css
 
 
 # Update PhantomJS (v10 compat)
-if [ "${PHANTOMJS_VERSION}" != "OS" ];
-then
+if [ "${PHANTOMJS_VERSION}" != "OS" ]; then
     npm install --prefix ${TRAVIS_BUILD_DIR} "phantomjs-prebuilt@${PHANTOMJS_VERSION:=latest}"
     ln -s "${TRAVIS_BUILD_DIR}/node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs" "${HOME}/maintainer-quality-tools/travis/phantomjs"
 fi

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -32,6 +32,11 @@ ln -s `which nodejs` $HOME/maintainer-quality-tools/travis/node
 npm install -g less less-plugin-clean-css
 
 
+# Update PhantomJS (v10 compat)
+npm install --prefix ${TRAVIS_BUILD_DIR} phantomjs-prebuilt@2.1.14
+ln -s "${TRAVIS_BUILD_DIR}/node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs" "${HOME}/maintainer-quality-tools/travis/phantomjs"
+
+
 # For backward compatibility, take version from parameter if it's not globally set
 if [ "x${VERSION}" == "x" ] ; then
     VERSION="${1}"

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -33,9 +33,11 @@ npm install -g less less-plugin-clean-css
 
 
 # Update PhantomJS (v10 compat)
-npm install --prefix ${TRAVIS_BUILD_DIR} phantomjs-prebuilt@2.1.14
-ln -s "${TRAVIS_BUILD_DIR}/node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs" "${HOME}/maintainer-quality-tools/travis/phantomjs"
-
+if [ "${PHANTOMJS_VERSION}" != "OS" ];
+then
+    npm install --prefix ${TRAVIS_BUILD_DIR} "phantomjs-prebuilt@${PHANTOMJS_VERSION:=latest}"
+    ln -s "${TRAVIS_BUILD_DIR}/node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs" "${HOME}/maintainer-quality-tools/travis/phantomjs"
+fi
 
 # For backward compatibility, take version from parameter if it's not globally set
 if [ "x${VERSION}" == "x" ] ; then


### PR DESCRIPTION
* Add PhantomJS update to circumvent [MutationObserver](https://travis-ci.org/OCA/e-commerce/jobs/213050636#L847) error in V10

We have now used this to fix tours in 3 PRs:
* https://github.com/OCA/website/pull/329
* https://github.com/OCA/e-commerce/pull/155
* https://github.com/OCA/website/pull/331

The actual install/update adds all of 10 seconds on to the build. IMO this is better than requiring a change in relevant Travis files - this error is pretty hard to spot & took me a decent amount of time to wrestle down.

I switched OCA/website#329 to use this branch in https://github.com/OCA/website/pull/329/commits/82e5e8a06b6fb21a85e9b490d3cd44fb67473f9b to provide proof of fix.