### PR TITLE
[FIX] test_server: Support empty preinstall modules

### DIFF
--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -328,8 +328,9 @@ def main(argv=None):
     # setup the base module without running the tests
     preinstall_modules = get_test_dependencies(addons_path,
                                                tested_addons_list)
-    preinstall_modules = list(set(preinstall_modules) - set(get_modules(
-        os.environ.get('TRAVIS_BUILD_DIR'))))
+
+    preinstall_modules = list(set(preinstall_modules or []) - set(get_modules(
+        os.environ.get('TRAVIS_BUILD_DIR')) or [])) or ['base']
     print("Modules to preinstall: %s" % preinstall_modules)
     setup_server(dbtemplate, odoo_unittest, tested_addons, server_path,
                  script_name, addons_path, install_options, preinstall_modules,


### PR DESCRIPTION
Fix the following output

"""
Modules to test: base
'NoneType' object is not iterable

+=======================================
|  Tests summary:
|---------------------------------------
| test_server.py              FAIL
+=======================================
"""