### PR TITLE
[FIX] install: Remove deprecated download.gna.org

### DIFF
--- a/travis/requirements.txt
+++ b/travis/requirements.txt
@@ -1,4 +1,4 @@
-http://download.gna.org/pychart/PyChart-1.39.tar.gz
+Python-Chart==1.39
 babel >= 1.0
 decorator
 docutils

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -83,7 +83,7 @@ if [ "$clone_result" != "0"  ]; then
 fi;
 
 echo "Install webkit (wkhtmltopdf) patched"
-(cd ${HOME}/maintainer-quality-tools/travis/ && wget -qO- https://downloads.wkhtmltopdf.org/wkhtmltopdf/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz | tar -xJ --strip-components=2 wkhtmltox/bin/wkhtmltopdf)
+(cd ${HOME}/maintainer-quality-tools/travis/ && wget -qO- https://downloads.wkhtmltopdf.org/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz | tar -xJ --strip-components=2 wkhtmltox/bin/wkhtmltopdf)
 
 # Expected directory structure:
 #

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -83,7 +83,7 @@ if [ "$clone_result" != "0"  ]; then
 fi;
 
 echo "Install webkit (wkhtmltopdf) patched"
-(cd ${HOME}/maintainer-quality-tools/travis/ && wget -qO- http://download.gna.org/wkhtmltopdf/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz | tar -xJ --strip-components=2 wkhtmltox/bin/wkhtmltopdf)
+(cd ${HOME}/maintainer-quality-tools/travis/ && wget -qO- https://downloads.wkhtmltopdf.org/wkhtmltopdf/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz | tar -xJ --strip-components=2 wkhtmltox/bin/wkhtmltopdf)
 
 # Expected directory structure:
 #


### PR DESCRIPTION
Travis show a error because can't download packages referenced to gna.org because now is closed:

Related with:
  -  https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3390
  - https://github.com/odoo/odoo/pull/6781

Of course, we could create a new method to get requirements.txt from odoo, but the focus of this PR is a small fix with current version.