### PR TITLE
[REF] install: Skip webkit installation if there is a issue

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -82,10 +82,9 @@ if [ "$clone_result" != "0"  ]; then
     exit $clone_result
 fi;
 
-echo "Install webkit (wkhtmltopdf) patched"
-(cd ${HOME}/maintainer-quality-tools/travis/ && wget -qO- -t 1 --timeout=240 https://downloads.wkhtmltopdf.org/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz | tar -xJ --strip-components=2 wkhtmltox/bin/wkhtmltopdf)
-if [ "$?" != "0" ]; then
-    echo "Warning: Webkit patched was not downloaded."
+if [ "${WKHTMLTOPDF_VERSION}" != "" ]; then
+    echo "Install webkit (wkhtmltopdf) patched version ${WKHTMLTOPDF_VERSION}"
+    (cd ${HOME}/maintainer-quality-tools/travis/ && wget -qO- -t 1 --timeout=240 https://downloads.wkhtmltopdf.org/0.12/${WKHTMLTOPDF_VERSION}/wkhtmltox-${WKHTMLTOPDF_VERSION}_linux-generic-amd64.tar.xz | tar -xJ --strip-components=2 wkhtmltox/bin/wkhtmltopdf)
 fi;
 
 # Expected directory structure:

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -83,7 +83,10 @@ if [ "$clone_result" != "0"  ]; then
 fi;
 
 echo "Install webkit (wkhtmltopdf) patched"
-(cd ${HOME}/maintainer-quality-tools/travis/ && wget -qO- https://downloads.wkhtmltopdf.org/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz | tar -xJ --strip-components=2 wkhtmltox/bin/wkhtmltopdf)
+(cd ${HOME}/maintainer-quality-tools/travis/ && wget -qO- -t 1 --timeout=240 https://downloads.wkhtmltopdf.org/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz | tar -xJ --strip-components=2 wkhtmltox/bin/wkhtmltopdf)
+if [ "$?" != "0" ]; then
+    echo "Warning: Webkit patched was not downloaded."
+fi;
 
 # Expected directory structure:
 #


### PR DESCRIPTION
The new host server there are many network issue.
Webkit is not a package required to run the tests correctly in the major of the builds.
So we can continue if there is a issue.