### PR TITLE
[FIX] Switch to wkhtmltopdf GitHub URI

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -84,7 +84,7 @@ fi;
 
 if [ "${WKHTMLTOPDF_VERSION}" != "" ]; then
     echo "Install webkit (wkhtmltopdf) patched version ${WKHTMLTOPDF_VERSION}"
-    (cd ${HOME}/maintainer-quality-tools/travis/ && wget -qO- -t 1 --timeout=240 https://downloads.wkhtmltopdf.org/0.12/${WKHTMLTOPDF_VERSION}/wkhtmltox-${WKHTMLTOPDF_VERSION}_linux-generic-amd64.tar.xz | tar -xJ --strip-components=2 wkhtmltox/bin/wkhtmltopdf)
+    (cd ${HOME}/maintainer-quality-tools/travis/ && wget -qO- -t 1 --timeout=240 https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox-${WKHTMLTOPDF_VERSION}_linux-generic-amd64.tar.xz | tar -xJ --strip-components=2 wkhtmltox/bin/wkhtmltopdf)
 fi;
 
 # Expected directory structure:


### PR DESCRIPTION
Our CI is failing due to https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3518. I propose that we switch to a Github mirror temporarily, then we can switch back once I get the notification on the ticket.

An alternative, which may actually be better, is to host our wkhtmltopdf inside of MQT & not deal with the remote downloads. This isn't the first time we've had issues with wkhtmltopdf installations.