### PR TITLE
Add helper comment to install a specific wkhtmltopdf version

### DIFF
--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -33,7 +33,7 @@ addons:
 env:
   global:
   - VERSION="8.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
-  - PHANTOMJS_VERSION="latest"export WKHTMLTOPDF_VERSION=0.12.4
+  - PHANTOMJS_VERSION="latest"
   # The above line controls the PhantomJS version that is used for JS testing.
   #   It is not necessary to include this value unless you are altering the default.
   #   Use `OS` to skip the PhantomJS upgrade & use the system version instead.

--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -33,7 +33,7 @@ addons:
 env:
   global:
   - VERSION="8.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
-  - PHANTOMJS_VERSION="latest"
+  - PHANTOMJS_VERSION="latest"export WKHTMLTOPDF_VERSION=0.12.4
   # The above line controls the PhantomJS version that is used for JS testing.
   #   It is not necessary to include this value unless you are altering the default.
   #   Use `OS` to skip the PhantomJS upgrade & use the system version instead.
@@ -80,6 +80,8 @@ install:
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
+# Use the sentence below to install a specific wkhtmltopdf version
+# - export WKHTMLTOPDF_VERSION=0.12.4
 
 script:
   - travis_run_tests


### PR DESCRIPTION
Sometimes it is important to install a specific wkhtmltopdf on a repo. Maintainers need to know how to properly set this up.

See https://github.com/OCA/reporting-engine/pull/144#discussion-diff-123189206R32 for an example.