### PR TITLE
[REF] install: pip install w/o --user

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -68,7 +68,7 @@ fi
 # Workaround to force using system site packages (see https://github.com/Shippable/support/issues/241#issuecomment-57947925)
 rm -f $VIRTUAL_ENV/lib/python2.7/no-global-site-packages.txt
 pip install --upgrade pip
-pip install --user -q --no-binary pycparser -r ${HOME}/maintainer-quality-tools/requirements.txt
+pip install -q --no-binary pycparser -r ${HOME}/maintainer-quality-tools/requirements.txt
 
 # Odoo <= 7.0 don't have requirements.txt file then the 8.0 file is used by default
 if [ ! -f ${ODOO_PATH}/requirements.txt ]; then
@@ -81,7 +81,7 @@ sed -i '/^python-ldap\=\=/d' ${ODOO_PATH}/requirements.txt
 # Use requests with [security] suffix to fix [Errno 111] Connection refused for old python2.7 versions.
 sed -i 's/^requests\=\=/requests[security]\=\=/g' ${ODOO_PATH}/requirements.txt
 
-pip install --user -q --no-binary pycparser -r ${ODOO_PATH}/requirements.txt
+pip install -q --no-binary pycparser -r ${ODOO_PATH}/requirements.txt
 pip install -q QUnitSuite coveralls codecov
 
 # Use reference .coveragerc


### PR DESCRIPTION
Travis use a virtualenv to install python packages, if we use `pip install --user ...` then it will have 2 environments with possible errors like as:
https://github.com/OCA/l10n-spain/pull/569

Before this PR:
 - ![screen shot 2017-07-06 at 17 02 35](https://user-images.githubusercontent.com/6644187/27934379-0ce2c49a-626b-11e7-93d7-2b0344bf38a6.png)

After this PR:
 - ![screen shot 2017-07-06 at 17 25 08](https://user-images.githubusercontent.com/6644187/27935025-383d23b2-626e-11e7-9ac2-6850b69ce07d.png)

The `--user` parameters was added https://github.com/OCA/maintainer-quality-tools/pull/209 because a error from https://github.com/OCA/dotnet/pull/6 but that environment is not using a standard python image.

They are using:
https://docs.travis-ci.com/user/languages/csharp/
And the log show us: https://travis-ci.org/OCA/dotnet/builds/70875564#L113

```bash
C# support for Travis-CI is community maintained.
Please open any issues at https://github.com/travis-ci/travis-ci/issues/new and cc @joshua-anderson @akoeplinger @nterry
```

Then is not a standard build support by travis and this shouldn't a standard build support by us, in fact, that project is not compatible with OCA/MQT since too much previous commits.

Fix https://github.com/OCA/maintainer-quality-tools/issues/459