### PR TITLE
Install unittest2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ simplejson
 pyserial
 pyyaml
 coveralls
+unittest2
 
 # transifex requirements
 polib


### PR DESCRIPTION
A build failed due to unittest2 not installed:
https://travis-ci.org/OCA/connector/jobs/250791548#L647

Adding the lib in the project's local requirements.txt fixed the build:
https://github.com/OCA/connector/commit/3e8d50754252ea4fe764a79c6a7e0cdc0c4e4070

I don't know what changed, but the lib is required anyway.