### PR TITLE
[FIX] Fix builds by updating pyopenssl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 simplejson
 pyserial
+pyopenssl>=16.2.0
 pyyaml
 coveralls
 unittest2


### PR DESCRIPTION
Runbot has recently become broken due to `pyopenssl` compilation errors:

* https://runbot2.odoo-community.org/runbot/static/build/3298536-153-e1c46f/logs/job_20_test_all.txt
* https://runbot2.odoo-community.org/runbot/static/build/3298522-882-a8d59b/logs/job_20_test_all.txt

Current production build of server-tools was passing, but is now failing since I rebuilt:
* https://runbot.odoo-community.org/runbot/build/3298530

The traceback:
```
/home/odoo/odoo-10.0/odoo-bin -d openerp_template --log-level=info --stop-after-init --init base_search_fuzzy,website_sale,base
Traceback (most recent call last):
  File "/home/odoo/odoo-10.0/odoo-bin", line 5, in <module>
    __import__('pkg_resources').declare_namespace('odoo.addons')
  File "/.repo_requirements/virtualenv/python2.7/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2149, in declare_namespace
    declare_namespace(parent)
  File "/.repo_requirements/virtualenv/python2.7/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2165, in declare_namespace
    _handle_ns(packageName, path_item)
  File "/.repo_requirements/virtualenv/python2.7/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2100, in _handle_ns
    loader.load_module(packageName)
  File "/usr/lib/python2.7/pkgutil.py", line 246, in load_module
    mod = imp.load_module(fullname, self.file, self.filename, self.etc)
  File "/.repo_requirements/odoo/odoo/__init__.py", line 81, in <module>
    import cli
  File "/.repo_requirements/odoo/odoo/cli/__init__.py", line 9, in <module>
    import deploy
  File "/.repo_requirements/odoo/odoo/cli/deploy.py", line 5, in <module>
    import requests
  File "/.repo_requirements/virtualenv/python2.7/local/lib/python2.7/site-packages/requests/__init__.py", line 52, in <module>
    from .packages.urllib3.contrib import pyopenssl
  File "/.repo_requirements/virtualenv/python2.7/local/lib/python2.7/site-packages/requests/packages/urllib3/contrib/pyopenssl.py", line 54, in <module>
    import OpenSSL.SSL
  File "/usr/local/lib/python2.7/dist-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import rand, crypto, SSL
  File "/usr/local/lib/python2.7/dist-packages/OpenSSL/SSL.py", line 124, in <module>
    SSL_ST_INIT = _lib.SSL_ST_INIT
AttributeError: 'module' object has no attribute 'SSL_ST_INIT'
Command '['/home/odoo/odoo-10.0/odoo-bin', '-d', 'openerp_template', '--log-level=info', '--stop-after-init', '--init', 'base_search_fuzzy,website_sale,base']' returned non-zero exit status 1
```

From what I'm gathering with Google-fu, the solution looks to be updating `pyopenssl`:
* https://github.com/MobSF/Mobile-Security-Framework-MobSF/issues/293
* https://github.com/EmpireProject/Empire/issues/429
* https://stackoverflow.com/questions/43267157/python-attributeerror-module-object-has-no-attribute-ssl-st-init

This is a PoC of a fix, to be confirmed if it works.