### PR TITLE
[IMP] Add shortcut to install SASS and Compass

### DIFF
--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -43,6 +43,10 @@ env:
   # The above line controls the PhantomJS version that is used for JS testing.
   #   It is not necessary to include this value unless you are altering the default.
   #   Use `OS` to skip the PhantomJS upgrade & use the system version instead.
+  - WEBSITE_REPO="1"
+  # Use the above line to install dependencies that are required for website repos:
+  # * SASS & Bootstrap-SASS
+  # * Compass
   - TRANSIFEX_USER='transbot@odoo-community.org'
   # This line contains the encrypted transifex password
   # To encrypt transifex password, install travis ruby utils with:

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -32,10 +32,9 @@ ln -s `which nodejs` $HOME/maintainer-quality-tools/travis/node
 npm install -g less less-plugin-clean-css
 
 if [ "${WEBSITE_REPO}" == "1" ]; then
-    rvm install ruby 2.0 &&
-    rvm use 2.0 &&
-    gem install bootstrap-sass &&
-    gem install compass --pre
+    rvm install ruby --latest
+    rvm use ruby --latest
+    gem install compass bootstrap-sass
 fi
 
 # Update PhantomJS (v10 compat)

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -31,6 +31,12 @@ fi
 ln -s `which nodejs` $HOME/maintainer-quality-tools/travis/node
 npm install -g less less-plugin-clean-css
 
+if [ "${WEBSITE_REPO}" == "1" ]; then
+    rvm install ruby 2.0 &&
+    rvm use 2.0 &&
+    gem install bootstrap-sass &&
+    gem install compass --pre
+fi
 
 # Update PhantomJS (v10 compat)
 if [ "${PHANTOMJS_VERSION}" != "OS" ]; then


### PR DESCRIPTION
This adds a shortcut for the installation of website dependencies SASS and Compass, which has been causing some considerable issues lately. Most recent 
* https://github.com/OCA/website/pull/361#issuecomment-316003296
* https://github.com/OCA/social/pull/179#issuecomment-316238557
cc @moylop260 @Yajo 