### PR TITLE
[FIX] travis_weblate.py: Create folder i18n and *.po file

### DIFF
--- a/travis/apis.py
+++ b/travis/apis.py
@@ -51,6 +51,8 @@ class WeblateApi(Request):
         self._token = os.environ.get("WEBLATE_TOKEN")
         self.host = os.environ.get(
             "WEBLATE_HOST", "https://weblate.odoo-community.org/api")
+        self.ssh = os.environ.get(
+            "WEBLATE_SSH", "ssh://user@webpage.com")
         self.tempdir = os.path.join(tempfile.gettempdir(), 'weblate_api')
 
     def get_project(self, repo_slug, branch):

--- a/travis/apis.py
+++ b/travis/apis.py
@@ -78,9 +78,6 @@ class WeblateApi(Request):
         components = []
         values = self._request(
             self.host + '/projects/%s/components/' % self.project['slug'])
-        if not values['results']:
-            raise ApiException('No components found in the project "%s"' %
-                               self.project['slug'])
         for value in values['results']:
             if value['branch'] and value['branch'] != self.branch:
                 continue

--- a/travis/travis_weblate.py
+++ b/travis/travis_weblate.py
@@ -102,12 +102,11 @@ class TravisWeblateUpdate(object):
             modules = odoo_context.cr.dictfetchall()
             self._installed_modules = [module['name'] for module in modules]
 
-    def _generate_odoo_po_files(self, component):
+    def _generate_odoo_po_files(self, module, only_installed=True):
         generated = False
         with self._connection_context(self._server_path, self._addons_path,
                                       self._database) as odoo_context:
-            module = component['name']
-            if module not in self._installed_modules:
+            if only_installed and module not in self._installed_modules:
                 return generated
             print("\n", yellow("Obtaining POT file for %s" % module))
             i18n_folder = os.path.join(self._travis_build_dir, module, 'i18n')
@@ -124,6 +123,8 @@ class TravisWeblateUpdate(object):
                 with open(os.path.join(i18n_folder, lang + '.po'), 'wb')\
                         as f_po:
                     f_po.write(po_content)
+                    if self._git.run(["add", "-v", f_po.name]):
+                        generated = True
             for po_file_name in po_files:
                 lang = os.path.basename(os.path.splitext(po_file_name)[0])
                 if self._langs and lang not in self._langs:
@@ -206,9 +207,6 @@ class TravisWeblateUpdate(object):
     def update(self):
         self._check()
         self.wl_api.load_project(self.repo_name, self.branch)
-        if not self.wl_api.components:
-            print yellow("No component found for %s" % self.repo_name)
-            return 1
         with self.wl_api.component_lock():
             self._git.run(["fetch", "origin"])
             first_commit = False
@@ -223,7 +221,7 @@ class TravisWeblateUpdate(object):
                 self.wl_api.component_repository(component, 'pull')
                 self._git.run(["remote", "add", name, remote])
                 self._git.run(["fetch", name])
-                if self._generate_odoo_po_files(component):
+                if self._generate_odoo_po_files(component['name']):
                     first_commit = self._commit_weblate(first_commit)
                 self._git.run(["merge", "--squash", "-s", "recursive", "-X",
                                "ours", "%s/%s" % (name, self.branch)])
@@ -237,6 +235,14 @@ class TravisWeblateUpdate(object):
                 if self._check_conflict(component):
                     break
                 first_commit = self._commit_weblate(first_commit)
+            modules_no_processed = [module for module in
+                                    self._installed_modules if module not in
+                                    [comp['name'] for comp in
+                                     self.wl_api.components]]
+            for component in modules_no_processed:
+                if self._generate_odoo_po_files(component,
+                                                only_installed=False):
+                    first_commit = self._commit_weblate(first_commit)
             if not self._push_git_repository():
                 return 1
         return 0


### PR DESCRIPTION
When one module is not into the list of component on weblate, that module is excluded for `travis_weblate.py`

In this pull request this mistage was fixes up.
Based on the modules installed and the components registered on weblate, if that module is installed but the same module is not present into the weblate component now the folder `i18n` and the *.po files is going to created

Only the environment variable `LANG_ALLOWED` should be setter to a default list of languages supported

Related with https://github.com/Vauxoo/maintainer-quality-tools/pull/219