### PR TITLE
[REF] install: Re-active pip install lxml

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -7,7 +7,6 @@ if [ "${LINT_CHECK}" != "0" ]; then
 
     # Install pylint plugin depends without lxml
     wget -q https://raw.githubusercontent.com/OCA/pylint-odoo/master/requirements.txt -O ${HOME}/maintainer-quality-tools/travis/pylint_odoo_requirements.txt
-    find -L ${HOME}/maintainer-quality-tools/travis -name pylint_odoo_requirements.txt -exec sed -i '/lxml/d'  {} \;  #  lxml depends is too slow
     pip install --upgrade -r ${HOME}/maintainer-quality-tools/travis/pylint_odoo_requirements.txt
     pip install --upgrade --pre --no-deps git+https://github.com/OCA/pylint-odoo.git   # To use last version ever
     npm install -g eslint  # Extra package for pylint-odoo plugin

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -79,8 +79,6 @@ pip install -q --no-binary pycparser -r ${HOME}/maintainer-quality-tools/require
 if [ ! -f ${ODOO_PATH}/requirements.txt ]; then
     wget https://raw.githubusercontent.com/odoo/odoo/8.0/requirements.txt -O ${ODOO_PATH}/requirements.txt
 fi
-# Remove lxml from odoo requirements because is installed from apt package
-sed -i '/^lxml\=\=/d' ${ODOO_PATH}/requirements.txt
 # Remove python-ldap from odoo requirements because is not a common module used
 sed -i '/^python-ldap\=\=/d' ${ODOO_PATH}/requirements.txt
 # Use requests with [security] suffix to fix [Errno 111] Connection refused for old python2.7 versions.


### PR DESCRIPTION
Fix OCA/maintainer-quality-tools/#467

This change require use the new cache pip way to build faster:
 - https://github.com/OCA/maintainer-quality-tools/pull/257