### PR TITLE
[FIX] test_server.py: Adding more validation to detected ERROR and WARNING

### DIFF
--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -32,6 +32,7 @@ def has_test_errors(fname, dbname, odoo_version, check_loaded=True):
         ]
     errors_report = [
         lambda x: x['loglevel'] == 'CRITICAL',
+        lambda x: x['loglevel'] == 'ERROR',
         'At least one test failed',
         'no access rules, consider adding one',
         'invalid module names, ignored',


### PR DESCRIPTION
Relating to https://github.com/OCA/maintainer-quality-tools/issues/447#issuecomment-311502587

With this small change now travis is red if in the log has one `ERROR`

I made one PR of test related with this https://github.com/JesusZapata/project/pull/1

![image](https://user-images.githubusercontent.com/1387970/29077931-26be7c76-7c27-11e7-88b6-075bee36815b.png)

And now the travis is red



