### PR TITLE
[FIX] apis.py: Fix when the components on weblate are more 25

### DIFF
--- a/travis/apis.py
+++ b/travis/apis.py
@@ -78,9 +78,17 @@ class WeblateApi(Request):
 
     def get_components(self):
         components = []
-        values = self._request(
-            self.host + '/projects/%s/components/' % self.project['slug'])
-        for value in values['results']:
+        values = []
+        page = 1
+        while True:
+            data = self._request(self.host +
+                                 '/projects/%s/components/?page=%s' %
+                                 (self.project['slug'], page))
+            values.extend(data['results'] or [])
+            if not data['next']:
+                break
+            page += 1
+        for value in values:
             if value['branch'] and value['branch'] != self.branch:
                 continue
             components.append(value)


### PR DESCRIPTION
When the components it is more that 25 the API of Weblate paginated the results, then should be get each page

For more information https://docs.weblate.org/en/latest/api.html#any--

Related with https://github.com/Vauxoo/maintainer-quality-tools/pull/231