### PR TITLE
[FIX] apis.py: Adding new metod _ssh_keyscan to run the ssh-keyscan over the weblate-ssh server

### DIFF
--- a/tests/test_repo/broken_deprecated/__openerp__.py
+++ b/tests/test_repo/broken_deprecated/__openerp__.py
@@ -3,7 +3,7 @@
     'name': 'Broken deprecated module for tests MQT',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA)',
-    'version': '8.0.0.1.0.0',
+    'version': '8.0.1.0.0',
     'depends': [
         'base',
     ],

--- a/travis/apis.py
+++ b/travis/apis.py
@@ -73,7 +73,7 @@ class WeblateApi(Request):
         cmd.append(data['port'] or '22')
         cmd.append(data['host'])
         with open(os.path.expanduser('~/.ssh/known_hosts'), 'a+') as hosts:
-             subprocess.Popen(cmd, stdout=hosts)
+            subprocess.Popen(cmd, stdout=hosts)
 
     def get_project(self, repo_slug, branch):
         self.branch = branch


### PR DESCRIPTION
When is it used the command `git clone` over the ssh the command need a console to answer the follow question

`Are you sure you want to continue connecting (yes/no)? `

With the command `ssh-keyscan` get the key a Weblate ssh server and skip the previous question