### PR TITLE
[IMP] Alow excluding specified modules from test_flake8 using env var

### DIFF
--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -262,6 +262,11 @@ def run_pylint(paths, cfg, beta_msgs=None, sys_paths=None, extra_params=None):
     subpaths = get_subpaths(paths)
     if not subpaths:
         raise UserWarning("Python modules not found in paths %s" % (paths))
+    exclude = os.environ.get('EXCLUDE', '').split(',')
+    subpaths = [path for path in subpaths
+                if os.path.basename(path) not in exclude]
+    if not subpaths:
+        return {'error': 0}
     cmd.extend(subpaths)
     pylint_res = pylint.lint.Run(cmd, exit=False)
     return pylint_res.linter.stats

--- a/travis/test_flake8
+++ b/travis/test_flake8
@@ -11,6 +11,9 @@ flake8_config_dir = os.path.join(root_dir, 'cfg')
 folders = (os.environ.get("INCLUDE_LINT", "").split() or
            get_modules(os.path.abspath('.')))
 
+exclude = os.environ.get('EXCLUDE', '').split(',')
+folders = [folder for folder in folders if folder not in exclude]
+
 status = 0
 
 for addon in folders:


### PR DESCRIPTION
With this MR we will be able to use the environment variable `EXCLUDE_FLAKE8` to specify modules to be excluded from the flake8 checks.

Use case: sometimes we need to ignore the warnings for some modules because they are from a third party and we don't/can't maintain them.

Example:

![image](https://user-images.githubusercontent.com/8657959/30599677-d6f56d22-9d22-11e7-81d0-09aa1069fce8.png)

Here we are getting a lot of warnings from some third party modules, but we can skip them like this:

![image](https://user-images.githubusercontent.com/8657959/30599693-eacdc88a-9d22-11e7-92ff-dd838b5e7fc3.png)

And then we see the warnings for the modules that correspond to us to maintain, and our CI tests don't display the false alarms.