### PR TITLE
[FIX] apis.py: Fix the regular expression to detect the domain containing '-'

### DIFF
--- a/travis/apis.py
+++ b/travis/apis.py
@@ -65,8 +65,8 @@ class WeblateApi(Request):
             'Are you sure you want to continue connecting (yes/no)?'"""
         cmd = ['ssh-keyscan', '-p']
         match = re.search(
-            r'(ssh\:\/\/\w+@(?P<host>[\w\.]+))(:{0,1})(?P<port>(\d+))?',
-            self.ssh)
+            r'(ssh\:\/\/\w+@(?P<host>[a-zA-Z0-9_.-]+))(:{0,1})'
+            '(?P<port>(\d+))?', self.ssh)
         if not match:
             return False
         data = match.groupdict()

--- a/travis/apis.py
+++ b/travis/apis.py
@@ -66,7 +66,7 @@ class WeblateApi(Request):
         cmd = ['ssh-keyscan', '-p']
         match = re.search(
             r'(ssh\:\/\/\w+@(?P<host>[a-zA-Z0-9_.-]+))(:{0,1})'
-            '(?P<port>(\d+))?', self.ssh)
+            r'(?P<port>(\d+))?', self.ssh)
         if not match:
             return False
         data = match.groupdict()


### PR DESCRIPTION
Change the regular expression to support domain containing '-' equal to `translation.odoo-community.org`

![image](https://user-images.githubusercontent.com/1387970/30603672-3c3c14ac-9d36-11e7-9376-631522e602ef.png)
