### PR TITLE
[REF] MQT: Migration to python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,31 +31,31 @@ matrix:
     - python: 2.7
       env:
         VERSION="9.0" TESTS="1" LINT_CHECK="0"
-        TESTS="1" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB" MQT_TEMPLATE_DB='mqt_odoo_template_core' MQT_TEST_DB='mqt_odoo_core'
+        INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB" MQT_TEMPLATE_DB='mqt_odoo_template_core' MQT_TEST_DB='mqt_odoo_core'
     - python: 2.7
       env:
-        VERSION="9.0" TESTS="1" LINT_CHECK="0"
-        LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="19" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
+        VERSION="9.0" TESTS="0" LINT_CHECK="1"
+        PYLINT_EXPECTED_ERRORS="19" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
     - python: 2.7
       env:
-        VERSION="9.0" TESTS="1" LINT_CHECK="0"
-        VERSION=master EXCLUDE="broken_no_access_rule" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="32" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
+        VERSION="master" TESTS="0" LINT_CHECK="1"
+        EXCLUDE="broken_no_access_rule" PYLINT_EXPECTED_ERRORS="32" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
     - python: 2.7
       env:
-        VERSION="9.0" TESTS="1" LINT_CHECK="0"
-        VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="30" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
+        VERSION="7.0" TESTS="0" LINT_CHECK="1"
+        PYLINT_EXPECTED_ERRORS="30" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
     - python: 2.7
       env:
-        VERSION="9.0" TESTS="1" LINT_CHECK="0"
-        VERSION="" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="19" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
+        VERSION="" TESTS="0" LINT_CHECK="1"
+        PYLINT_EXPECTED_ERRORS="19" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
     - python: 2.7
       env:
         VERSION="9.0" TESTS="1" LINT_CHECK="0"
         INCLUDE="broken_no_access_rule" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
     - python: 3.4
       env:
-        VERSION="9.0" TESTS="1" LINT_CHECK="0"
-        VERSION="saas-18" ODOO_REPO="odoo/odoo" INCLUDE="test_module,second_module"
+        VERSION="saas-18" TESTS="1" LINT_CHECK="0"  # TODO: Change to VERSION="11.0" if is released
+        INCLUDE="test_module,second_module"
 
 install:
   - cp -r ../maintainer-quality-tools/ $HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,19 +35,19 @@ matrix:
     - python: 2.7
       env:
         VERSION="9.0" TESTS="0" LINT_CHECK="1"
-        PYLINT_EXPECTED_ERRORS="18" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
+        PYLINT_EXPECTED_ERRORS="20" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
     - python: 2.7
       env:
         VERSION="master" TESTS="0" LINT_CHECK="1"
-        EXCLUDE="broken_no_access_rule" PYLINT_EXPECTED_ERRORS="31" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
+        EXCLUDE="broken_no_access_rule" PYLINT_EXPECTED_ERRORS="33" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
     - python: 2.7
       env:
         VERSION="7.0" TESTS="0" LINT_CHECK="1"
-        PYLINT_EXPECTED_ERRORS="29" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
+        PYLINT_EXPECTED_ERRORS="31" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
     - python: 2.7
       env:
         VERSION="" TESTS="0" LINT_CHECK="1"
-        PYLINT_EXPECTED_ERRORS="18" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
+        PYLINT_EXPECTED_ERRORS="20" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
     - python: 2.7
       env:
         VERSION="9.0" TESTS="1" LINT_CHECK="0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
       env:
         VERSION="9.0" TESTS="1" LINT_CHECK="0"
         INCLUDE="broken_no_access_rule" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
-    - python: 3.4
+    - python: 3.5
       env:
         VERSION="11.0" ODOO_REPO="OCA/OCB" TESTS="1" LINT_CHECK="0"
         INCLUDE="test_module,second_module"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,19 +35,19 @@ matrix:
     - python: 2.7
       env:
         VERSION="9.0" TESTS="0" LINT_CHECK="1"
-        PYLINT_EXPECTED_ERRORS="19" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
+        PYLINT_EXPECTED_ERRORS="18" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
     - python: 2.7
       env:
         VERSION="master" TESTS="0" LINT_CHECK="1"
-        EXCLUDE="broken_no_access_rule" PYLINT_EXPECTED_ERRORS="32" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
+        EXCLUDE="broken_no_access_rule" PYLINT_EXPECTED_ERRORS="31" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
     - python: 2.7
       env:
         VERSION="7.0" TESTS="0" LINT_CHECK="1"
-        PYLINT_EXPECTED_ERRORS="30" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
+        PYLINT_EXPECTED_ERRORS="29" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
     - python: 2.7
       env:
         VERSION="" TESTS="0" LINT_CHECK="1"
-        PYLINT_EXPECTED_ERRORS="19" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
+        PYLINT_EXPECTED_ERRORS="18" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
     - python: 2.7
       env:
         VERSION="9.0" TESTS="1" LINT_CHECK="0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
       env:
         VERSION="9.0" TESTS="0" LINT_CHECK="1"
         PYLINT_EXPECTED_ERRORS="19" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
-    - python: 3.4
+    - python: 2.7
       env:
         VERSION="master" TESTS="0" LINT_CHECK="1"
         EXCLUDE="broken_no_access_rule" PYLINT_EXPECTED_ERRORS="32" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
       env:
         VERSION="9.0" TESTS="0" LINT_CHECK="1"
         PYLINT_EXPECTED_ERRORS="19" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
-    - python: 2.7
+    - python: 3.4
       env:
         VERSION="master" TESTS="0" LINT_CHECK="1"
         EXCLUDE="broken_no_access_rule" PYLINT_EXPECTED_ERRORS="32" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,35 +8,54 @@ cache:
   directories:
     - $HOME/.cache/pip
 
-python:
-  - "2.7"
-
 addons:
   apt:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml  # because pip installation is slow
 
-virtualenv:
-  system_site_packages: true
-
-env:
-
-  global:
-  - VERSION="9.0" TESTS="1" LINT_CHECK="0"
-
-  matrix:
-  - INSTANCE_ALIVE="1" INCLUDE="broken_module" SERVER_EXPECTED_ERRORS="2"  # test errors are detected
-  - EXCLUDE="broken_module,broken_lint,broken_no_access_rule" OPTIONS="--log-level=debug" INSTALL_OPTIONS="--log-level=info" RUN_COMMAND_MQT_CREATE_FOLDER='mkdir /tmp/tests'
-  - INCLUDE="test_module,second_module" UNIT_TEST="1"
-  - VERSION="7.0" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB"  # ODOO_REPO usage example
-  - TESTS="1" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB" MQT_TEMPLATE_DB='mqt_odoo_template_core' MQT_TEST_DB='mqt_odoo_core'
-  - VERSION="6.1" INCLUDE="test_module,second_module"
-  - LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="21" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
-  - VERSION=master EXCLUDE="broken_no_access_rule" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="34" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
-  - VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="32" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
-  - VERSION="" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="21" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
-  - INCLUDE="broken_no_access_rule" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
+matrix:
+  include:
+    - python: 2.7
+      env:
+        VERSION="9.0" TESTS="1" LINT_CHECK="0"
+        INSTANCE_ALIVE="1" INCLUDE="broken_module" SERVER_EXPECTED_ERRORS="2"  # test errors are detected
+    - python: 2.7
+      env:
+        VERSION="9.0" TESTS="1" LINT_CHECK="0"
+        EXCLUDE="broken_module,broken_lint,broken_no_access_rule" OPTIONS="--log-level=debug" INSTALL_OPTIONS="--log-level=info" RUN_COMMAND_MQT_CREATE_FOLDER='mkdir /tmp/tests'
+    - python: 2.7
+      env:
+        VERSION="9.0" TESTS="1" LINT_CHECK="0"
+        INCLUDE="test_module,second_module" UNIT_TEST="1"
+    - python: 2.7
+      env:
+        VERSION="9.0" TESTS="1" LINT_CHECK="0"
+        TESTS="1" INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB" MQT_TEMPLATE_DB='mqt_odoo_template_core' MQT_TEST_DB='mqt_odoo_core'
+    - python: 2.7
+      env:
+        VERSION="9.0" TESTS="1" LINT_CHECK="0"
+        LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="19" TRAVIS_PULL_REQUEST="false" # Use main pylint config file
+    - python: 2.7
+      env:
+        VERSION="9.0" TESTS="1" LINT_CHECK="0"
+        VERSION=master EXCLUDE="broken_no_access_rule" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="32" TRAVIS_PULL_REQUEST="true"  # Use PR pylint config file
+    - python: 2.7
+      env:
+        VERSION="9.0" TESTS="1" LINT_CHECK="0"
+        VERSION="7.0" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="30" TRAVIS_PULL_REQUEST="true"  # To check pylint_conf of PR's with old api
+    - python: 2.7
+      env:
+        VERSION="9.0" TESTS="1" LINT_CHECK="0"
+        VERSION="" LINT_CHECK="1" TESTS="0" PYLINT_EXPECTED_ERRORS="19" TRAVIS_PULL_REQUEST="false"  # To check VERSION empty or unset case.
+    - python: 2.7
+      env:
+        VERSION="9.0" TESTS="1" LINT_CHECK="0"
+        INCLUDE="broken_no_access_rule" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
+    - python: 3.4
+      env:
+        VERSION="9.0" TESTS="1" LINT_CHECK="0"
+        VERSION="saas-18" ODOO_REPO="odoo/odoo" INCLUDE="test_module,second_module"
 
 install:
   - cp -r ../maintainer-quality-tools/ $HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
         INCLUDE="broken_no_access_rule" SERVER_EXPECTED_ERRORS="1"  # test errors are detected
     - python: 3.4
       env:
-        VERSION="saas-18" TESTS="1" LINT_CHECK="0"  # TODO: Change to VERSION="11.0" if is released
+        VERSION="11.0" ODOO_REPO="OCA/OCB" TESTS="1" LINT_CHECK="0"
         INCLUDE="test_module,second_module"
 
 install:

--- a/tests/test_repo/broken_lint/case_fields.py
+++ b/tests/test_repo/broken_lint/case_fields.py
@@ -6,16 +6,14 @@ from openerp.tools.translate import _
 
 class MyExampleField(models.Model):
     _name = "my.example.field"
-    _columns = {
-        'name': fields.char(_('Title'), 100),
-        'description': fields.char(string=_('Description'), size=100),
-    }
+    name = fields.Char(_('Title'), size=100)
+    description = fields.Char(string=_('Description'), size=100)
 
 
 class MyExampleField2(models.Model):
     _name = "my.example.field2"
 
-    name = fields.Char(_('Title'), 100)
+    name = fields.Char(_('Title'), size=100)
     description = fields.Char(name=_('Description'), size=100)
 
     def my_method1(self, var):

--- a/tests/test_repo/broken_module/model.py
+++ b/tests/test_repo/broken_module/model.py
@@ -1,17 +1,19 @@
 # missing coding
-from openerp.osv import orm, fields
+from __future__ import print_function
+
+from openerp.osv import orm
+from openerp import fields
 
 import os
 import os as os2  # W0404 - duplicated import
 
-import __openerp__  # W0403 - relative import
+# py3 don't support relative import anymore
+# import __openerp__  # W0403 - relative import
 
 
 class test_model(orm.Model):
     _name = "test.model"
-    _columns = {
-        'name': fields.char('Title', 100),
-    }
+    name = fields.Char('Title', size=100)
 
     def method_test(self, arg1, arg2):
         return None
@@ -25,7 +27,7 @@ class test_model(orm.Model):
         return "%s %s" % ('value1')
 
     def method_e1601(self):
-        print "Hello world!"
+        print("Hello world!")
 
     def method_w0101(self):
         return True
@@ -34,7 +36,7 @@ class test_model(orm.Model):
     def method_w0102(self, arg1, arg2=[]):
         # avoid imported but unused
         all_imports = (
-            os, os2, __openerp__)
+            os, os2)
         return all_imports
 
     def method_w0104_w0105(self):

--- a/tests/test_repo/broken_module/model.py
+++ b/tests/test_repo/broken_module/model.py
@@ -1,6 +1,4 @@
 # missing coding
-from __future__ import print_function
-
 from openerp.osv import orm
 from openerp import fields
 

--- a/tests/test_repo/broken_no_access_rule/dummy_model.py
+++ b/tests/test_repo/broken_no_access_rule/dummy_model.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from openerp.osv import fields, orm
+from openerp.osv import orm
+from openerp import fields
 
 
 class DummyModel(orm.Model):
     # expect "no access rules" error
     _name = 'another.dummy.model'
-    _columns = {
-        'name': fields.char('Dummy', size=100),
-    }
+    name = fields.Char('Dummy', size=100)

--- a/tests/test_repo/broken_uninstallable/model.py
+++ b/tests/test_repo/broken_uninstallable/model.py
@@ -1,5 +1,4 @@
 # missing coding
-from __future__ import print_function
 from openerp.osv import orm
 from openerp import fields
 

--- a/tests/test_repo/broken_uninstallable/model.py
+++ b/tests/test_repo/broken_uninstallable/model.py
@@ -1,5 +1,7 @@
 # missing coding
-from openerp.osv import orm, fields
+from __future__ import print_function
+from openerp.osv import orm
+from openerp import fields
 
 import os
 import os as os2  # W0404 - duplicated import
@@ -9,9 +11,7 @@ import __openerp__  # W0403 - relative import
 
 class test_model(orm.Model):
     _name = "test.model"
-    _columns = {
-        'name': fields.char('Title', 100),
-    }
+    name = fields.Char('Title', size=100)
 
     def method_test(self, arg1, arg2):
         return None
@@ -25,7 +25,7 @@ class test_model(orm.Model):
         return "%s %s" % ('value1')
 
     def method_e1601(self):
-        print "Hello world!"
+        print("Hello world!")
 
     def method_w0101(self):
         return True

--- a/tests/test_repo/test_module/dummy_model.py
+++ b/tests/test_repo/test_module/dummy_model.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from openerp.osv import fields, orm
+from openerp.osv import orm
+from openerp import fields
 import sys
 
 
 class DummyModel(orm.Model):
     _name = 'dummy.model'
-    _columns = {
-        'name': fields.char('Dummy', size=100),
-    }
+    name = fields.Char('Dummy', size=100)
 
 
 # printout non-ASCII text to check unicode issues

--- a/travis/getaddons.py
+++ b/travis/getaddons.py
@@ -5,7 +5,6 @@ Given a list  of paths, finds and returns a list of valid addons paths.
 With -m flag, will return a list of modules names instead.
 """
 
-from __future__ import print_function
 import ast
 import os
 import sys

--- a/travis/git_run.py
+++ b/travis/git_run.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
 import subprocess
 from six import string_types
 

--- a/travis/git_run.py
+++ b/travis/git_run.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import subprocess
+from six import string_types
 
 
 class GitRun(object):
@@ -15,12 +17,12 @@ class GitRun(object):
         :return: String output of command executed.
         """
         cmd = ['git', '--git-dir=' + self.repo_path] + command
-        print cmd if self.debug else ''
+        print(cmd if self.debug else '')
         try:
             res = subprocess.check_output(cmd)
         except subprocess.CalledProcessError:
             res = None
-        if isinstance(res, basestring):
+        if isinstance(res, string_types):
             res = res.strip('\n')
         return res
 
@@ -35,7 +37,7 @@ class GitRun(object):
         command = ['diff-index', '--name-only',
                    '--cached', base_ref]
         res = self.run(command)
-        items = res.split('\n') if res else []
+        items = res.decode('UTF-8').split('\n') if res else []
         return items
 
     def get_branch_name(self):

--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import os
 import sys
 

--- a/travis/self_tests
+++ b/travis/self_tests
@@ -1,16 +1,24 @@
 #!/usr/bin/env python
+# coding: utf-8
+
+from __future__ import print_function
 
 import os
 import subprocess
 import threading
 import time
-import xmlrpclib
 
 import getaddons
 import travis_helpers
 from test_server import main as test_server_main
 from test_server import get_test_dependencies
 from test_server import get_server_script
+
+try:
+    import xmlrpc.client as xmlrpclib
+except ImportError:
+    import xmlrpclib
+
 
 repo_dir = os.environ.get("TRAVIS_BUILD_DIR", ".")
 repo_dir_with_subfolders = os.path.join(
@@ -43,7 +51,7 @@ addon_paths_alfanumerical_order_should = [
 combined = []
 for i, item in enumerate(addon_paths_alfanumerical_order_should):
     combined.append([addon_paths_alfanumerical_order_is[i], item])
-print combined.__repr__()
+print(combined.__repr__())
 assert len(combined) == len(addon_paths_alfanumerical_order_is)
 for ist, should in combined:
     assert ist.rstrip('/').rstrip('\\').endswith(should)

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -45,13 +45,17 @@ Use the following types of pylint configuration files:
 
 import os
 import re
-import ConfigParser
 
 import run_pylint
 import travis_helpers
 
 from getaddons import get_modules_changed
 from git_run import GitRun
+
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 
 
 def get_extra_params(odoo_version):

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 from __future__ import print_function
 
@@ -8,6 +9,7 @@ import os
 import shutil
 import subprocess
 import sys
+from six import string_types
 from getaddons import get_addons, get_modules, is_installable_module
 from travis_helpers import success_msg, fail_msg
 
@@ -43,7 +45,7 @@ def has_test_errors(fname, dbname, odoo_version, check_loaded=True):
 
     def make_pattern_list_callable(pattern_list):
         for i in range(len(pattern_list)):
-            if isinstance(pattern_list[i], basestring):
+            if isinstance(pattern_list[i], string_types):
                 regex = re.compile(pattern_list[i])
                 pattern_list[i] = lambda x, regex=regex:\
                     regex.search(x['message'])
@@ -257,7 +259,7 @@ def run_from_env_var(env_name_startswith, environ):
     '''
     commands = [
         command
-        for environ_variable, command in sorted(environ.iteritems())
+        for environ_variable, command in sorted(environ.items())
         if environ_variable.startswith(env_name_startswith)
     ]
     for command in commands:
@@ -277,7 +279,7 @@ def create_server_conf(data, version):
         # present and only append our stuff
         fconf = open(fname_conf, "a")
         fconf.write('\n')
-    for key, value in data.iteritems():
+    for key, value in data.items():
         fconf.write(key + ' = ' + os.path.expanduser(value) + '\n')
     fconf.close()
 
@@ -426,10 +428,10 @@ def main(argv=None):
             pipe = subprocess.Popen(command_call,
                                     stderr=subprocess.STDOUT,
                                     stdout=subprocess.PIPE)
-            with open('stdout.log', 'w') as stdout:
-                for line in iter(pipe.stdout.readline, ''):
+            with open('stdout.log', 'wb') as stdout:
+                for line in iter(pipe.stdout.readline, b''):
                     stdout.write(line)
-                    print(line.strip())
+                    print(line.strip().decode('UTF-8'))
             returncode = pipe.wait()
             # Find errors, except from failed mails
             errors = has_test_errors(

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import ast
 import re
 import os

--- a/travis/travis_transifex.py
+++ b/travis/travis_transifex.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from __future__ import print_function
 from __future__ import unicode_literals
 import os
 import sys

--- a/travis/travis_weblate.py
+++ b/travis/travis_weblate.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+from __future__ import print_function
+
 import os
 import re
 import glob
@@ -73,7 +75,7 @@ class TravisWeblateUpdate(object):
             if os.path.isfile(p_file):
                 sed = ["sed", "-i", "-e",
                        r"s/translation'] = src/translation'] = ''/g", p_file]
-                print " ".join(sed)
+                print(" ".join(sed))
                 subprocess.call(sed)
             p_file = os.path.join(self._server_path, base,
                                   os.path.join('addons', 'base', 'ir',
@@ -81,7 +83,7 @@ class TravisWeblateUpdate(object):
             if os.path.isfile(p_file):
                 sed = ["sed", "-i", "-e",
                        r"s/if\snot\strans_dict\['value']:/if False:/g", p_file]
-                print " ".join(sed)
+                print(" ".join(sed))
                 subprocess.call(sed)
 
     def _get_modules_installed(self):
@@ -174,7 +176,7 @@ class TravisWeblateUpdate(object):
         self._git.run(["checkout", "-qb", self.branch,
                        "origin/%s" % self.branch])
         self._git.run(["branch", "-D", branch_name])
-        print yellow("The pull request register is: %s" % pull['html_url'])
+        print(yellow("The pull request register is: %s" % pull['html_url']))
 
     def _commit_weblate(self, first_commit=False):
         if ('nothing to commit, working tree clean'
@@ -213,15 +215,15 @@ class TravisWeblateUpdate(object):
             component = [item for item in self.wl_api.components
                          if item['git_export']]
             if len(component) > 1:
-                print yellow("To many repository for this project %s" %
-                             self.wl_api.project['name'])
+                print(yellow("To many repository for this project %s" %
+                             self.wl_api.project['name']))
                 return 1
             remote = (self.wl_api.ssh + '/' + self.wl_api.project['slug'] +
                       '/' + component[0]['slug'])
             name = '%s-wl' % self.wl_api.project['slug']
             self._git.run(["remote", "add", name, remote])
             for component in self.wl_api.components:
-                print yellow("Component %s" % component['slug'])
+                print(yellow("Component %s" % component['slug']))
                 self._git.run(["checkout", "-qb", self.branch,
                                "origin/%s" % self.branch])
                 self.wl_api.component_repository(component, 'pull')
@@ -257,7 +259,7 @@ def main(argv=None):
     try:
         TravisWeblateUpdate().update()
     except ApiException as exc:
-        print yellow(str(exc))
+        print(yellow(str(exc)))
         raise exc
 
 

--- a/travis/travis_weblate.py
+++ b/travis/travis_weblate.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from __future__ import print_function
-
 import os
 import re
 import glob


### PR DESCRIPTION
[REF] MQT: Migration to python3
  - [REF] remove relative import and reduce expected lint errors
  - [REF] py3: xmlrpclib compatilibity
  - [FIX] test_server: Write bytes for binary file and print string
  - [REF] Use br for regex

[REF] MQT: Compatibility with new api odoo

  - [REF] compatible with old and new api
  - [REF] remove deprecated _columns
  - [REF] .travis.yml: Remove 6.1 and 7.0 odoo test since that 11 version don't support _columns and 6.1 and 7.0 just suppport _columns

[REF] .travis.yml: Enable py3 environment