### PR TITLE
[REF] travis_install: Overwrite wkhtmltopdf if is installed

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -124,6 +124,11 @@ if [ "$clone_result" != "0"  ]; then
     exit $clone_result
 fi;
 
+if [ "${WKHTMLTOPDF_VERSION}" == "" && $(which wkhtmltopdf) != ""]; then
+    echo "You have installed wkhtmltopdf but is not patched (probably) then we will to overwrite it"
+    export WKHTMLTOPDF_VERSION="0.12.4"
+fi;
+
 if [ "${WKHTMLTOPDF_VERSION}" != "" ]; then
     echo "Install webkit (wkhtmltopdf) patched version ${WKHTMLTOPDF_VERSION}"
     (cd ${HOME}/maintainer-quality-tools/travis/ && wget -qO- -t 1 --timeout=240 https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox-${WKHTMLTOPDF_VERSION}_linux-generic-amd64.tar.xz | tar -xJ --strip-components=2 wkhtmltox/bin/wkhtmltopdf)


### PR DESCRIPTION
This PR is related with many false red because many projects don't have assigned the environment variable to install wkhtmltopdf patched version but the .travis.yml has `apt-get install wkhtmltopdf` so is failing because is not patched.

We can change all OCA projects to assign the environment varibable correctly but we can avoid many false red detecting if currently is installed then overwrite it.

What do you think about?

cc @Yajo @lasley @gurneyalex @sylvain-garancher 