### PR TITLE
Make condition more robust

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -124,7 +124,7 @@ if [ "$clone_result" != "0"  ]; then
     exit $clone_result
 fi;
 
-if [ "${WKHTMLTOPDF_VERSION}" == "" && $(which wkhtmltopdf) != "" ]; then
+if [ "${WKHTMLTOPDF_VERSION}" == "" -a "$(which wkhtmltopdf)" != "" ]; then
     echo "You have installed wkhtmltopdf but is not patched (probably) then we will to overwrite it"
     export WKHTMLTOPDF_VERSION="0.12.4"
 fi;


### PR DESCRIPTION
When wkhtmltopdf is not installed, the which command is empty therefore
the comparison fails with:

line 127: [: missing `]'

Also use '-a' instead of && which is recommended by SpellCheck (https://www.shellcheck.net/2

Example of failure in the wild: https://travis-ci.org/OCA/connector/jobs/282791133#L700