### PR TITLE
fix unbuffer issue

### DIFF
--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -14,7 +14,7 @@ addons:
 #    Search your sources alias here:
 #      https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
     packages:
-      - expect-dev  # provides unbuffer utility
+      - expect  # provides unbuffer utility
       - python-lxml  # because pip installation is slow
       - python-simplejson
       - python-serial


### PR DESCRIPTION
on ubuntu 14.04, expect-dev does not exist and
unbuffer is provided by expct