### PR TITLE
[FIX] Remove deprecated SASS note

### DIFF
--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -79,12 +79,6 @@ env:
 virtualenv:
   system_site_packages: true
 
-# Enable this if your repository needs sass command (needed for website related repos)
-#before_install:
-#  - rvm install ruby --latest
-#  - gem install bootstrap-sass
-#  - gem install compass --pre
-
 install:
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}


### PR DESCRIPTION
* Note about how to install SASS manually in Travis file is deprecated with `WEBSITE_REPO="1"`