### PR TITLE
[REF] travis/cfg: Enable the unnecessary-utf8-coding-comment check for beta and pr configuration

### DIFF
--- a/travis/cfg/travis_run_pylint_beta.cfg
+++ b/travis/cfg/travis_run_pylint_beta.cfg
@@ -24,6 +24,7 @@
 #   missing-newline-extrafiles - W7908
 #   missing-readme - C7902
 #   no-utf8-coding-comment - C8201
+#   unnecessary-utf8-coding-comment - C8202
 #   openerp-exception-warning - R8101
 #   redundant-modulename-xml - W7909
 #   rst-syntax-error - E7901
@@ -61,6 +62,7 @@ enabled2beta=api-one-deprecated,
     missing-newline-extrafiles,
     missing-readme,
     no-utf8-coding-comment,
+    unnecessary-utf8-coding-comment,
     odoo-addons-relative-import,
     old-api7-method-defined,
     openerp-exception-warning,

--- a/travis/cfg/travis_run_pylint_pr.cfg
+++ b/travis/cfg/travis_run_pylint_pr.cfg
@@ -48,6 +48,7 @@ disable=all
 #   missing-newline-extrafiles - W7908
 #   missing-readme - C7902
 #   no-utf8-coding-comment - C8201
+#   unnecessary-utf8-coding-comment - C8202
 #   openerp-exception-warning - R8101
 #   redundant-modulename-xml - W7909
 #   rst-syntax-error - E7901
@@ -91,6 +92,7 @@ enable=api-one-deprecated,
     missing-newline-extrafiles,
     missing-readme,
     no-utf8-coding-comment,
+    unnecessary-utf8-coding-comment,
     odoo-addons-relative-import,
     old-api7-method-defined,
     openerp-exception-warning,


### PR DESCRIPTION
Enable the `unnecessary-utf8-coding-comment` check for beta and pr configuration