### PR TITLE
[IMP] Allow using pylint beta cfg file in standalone mode

### DIFF
--- a/sample_files/.gitignore
+++ b/sample_files/.gitignore
@@ -37,8 +37,9 @@ coverage.xml
 # Translations
 *.mo
 
-# Pycharm
+# IDEs
 .idea
+.vscode
 
 # Mr Developer
 .mr.developer.cfg

--- a/travis/cfg/travis_run_pylint_beta.cfg
+++ b/travis/cfg/travis_run_pylint_beta.cfg
@@ -1,5 +1,11 @@
-# This file adds a list of messages that when activated by another
-#  pylint configuration file will display them without affecting your build status.
+[MASTER]
+profile=no
+ignore=CVS,.git,scenarios,.bzr
+persistent=yes
+cache-size=500
+
+[MESSAGES CONTROL]
+disable=all
 
 # Beta message and code:
 #   api-one-deprecated - W8104
@@ -36,8 +42,7 @@
 #   wrong-tabs-instead-of-spaces - W7910
 #   xml-syntax-error - E7902
 
-[MESSAGES CONTROL]
-enabled2beta=api-one-deprecated,
+enable=api-one-deprecated,
     api-one-multi-together,
     attribute-deprecated,
     class-camelcase,
@@ -75,3 +80,21 @@ enabled2beta=api-one-deprecated,
     use-vim-comment,
     wrong-tabs-instead-of-spaces,
     xml-syntax-error,
+
+[REPORTS]
+msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
+output-format=colorized
+files-output=no
+reports=no
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+comment=no
+
+[FORMAT]
+indent-string='    '
+
+[SIMILARITIES]
+ignore-comments=yes
+ignore-docstrings=yes
+
+[MISCELLANEOUS]
+notes=

--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -104,7 +104,7 @@ def get_beta_msgs():
     config.readfp(open(beta_cfg))
     return [
         msg.strip()
-        for msg in config.get('MESSAGES CONTROL', 'enabled').split(',')
+        for msg in config.get('MESSAGES CONTROL', 'enable').split(',')
         if msg.strip()]
 
 

--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -104,7 +104,7 @@ def get_beta_msgs():
     config.readfp(open(beta_cfg))
     return [
         msg.strip()
-        for msg in config.get('MESSAGES CONTROL', 'enabled2beta').split(',')
+        for msg in config.get('MESSAGES CONTROL', 'enabled').split(',')
         if msg.strip()]
 
 


### PR DESCRIPTION
By converting the beta file into a real pylint-odoo cfg file, other CI tools that allow a "failed but passing" status, such as Gitlab CI, can use pylint-odoo directly with this file without all the extra travis-specific complexity of MQT.
  
@Tecnativa