### PR TITLE
[IMP] Support $INCLUDE_LINT for flake8 too

### DIFF
--- a/travis/test_flake8
+++ b/travis/test_flake8
@@ -8,10 +8,12 @@ from getaddons import get_modules
 
 root_dir = os.path.dirname(os.path.abspath(__file__))
 flake8_config_dir = os.path.join(root_dir, 'cfg')
+folders = (os.environ.get("INCLUDE_LINT", "").split() or
+           get_modules(os.path.abspath('.')))
 
 status = 0
 
-for addon in get_modules(os.path.abspath('.')):
+for addon in folders:
     status += subprocess.call(['flake8', addon,
                                '--config=%s/travis_run_flake8__init__.cfg' %
                                flake8_config_dir])


### PR DESCRIPTION
Before this patch, you only can flake8 all code under $PWD. Now you can call it against any unrelated list of folders, mirroring what you can also do with pylint.

@Tecnativa