### PR TITLE
[FIX] tests: Update dictionary of expected errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,8 @@ install:
   - git --git-dir=${TRAVIS_BUILD_DIR}/.git add --all  # All modules moved are modules changed to test PR changes
 
 script:
-  - coverage run --append ./travis/travis_run_tests 8.0  # only used if VERSION not set in env
-  - TRAVIS_PULL_REQUEST="1" coverage run --append ./travis/self_tests
+  - TRAVIS_PULL_REQUEST="1" coverage run --append ./travis/travis_run_tests 8.0  # only used if VERSION not set in env
+  - coverage run --append ./travis/self_tests
 
 after_success:
    # Seudo-fix for codecov that is not processing "data_file" parameter

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB" MQT_TEMPLATE_DB='mqt_odoo_template_core' MQT_TEST_DB='mqt_odoo_core'
     - python: 2.7
       env:
-        VERSION="" TESTS="0" LINT_CHECK="1" TRAVIS_PULL_REQUEST="1"
+        VERSION="" TESTS="0" LINT_CHECK="1"
         PYLINT_EXPECTED_ERRORS="34"
     - python: 3.5
       env:
@@ -52,7 +52,7 @@ install:
 
 script:
   - coverage run --append ./travis/travis_run_tests 8.0  # only used if VERSION not set in env
-  - coverage run --append ./travis/self_tests
+  - TRAVIS_PULL_REQUEST="1" coverage run --append ./travis/self_tests
 
 after_success:
    # Seudo-fix for codecov that is not processing "data_file" parameter

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         INCLUDE="test_module,second_module" ODOO_REPO="OCA/OCB" MQT_TEMPLATE_DB='mqt_odoo_template_core' MQT_TEST_DB='mqt_odoo_core'
     - python: 2.7
       env:
-        VERSION="" TESTS="0" LINT_CHECK="1"
+        VERSION="" TESTS="0" LINT_CHECK="1" TRAVIS_PULL_REQUEST="1"
         PYLINT_EXPECTED_ERRORS="34"
     - python: 3.5
       env:

--- a/travis/self_tests
+++ b/travis/self_tests
@@ -48,7 +48,7 @@ EXPECTED_ERRORS_PR = {
     'license-allowed': 1,
     'manifest-required-author': 1,
     'manifest-required-key': 1,
-    'manifest-version-format': 6,
+    'manifest-version-format': 4,
 }
 
 
@@ -256,7 +256,6 @@ class MainTest(unittest.TestCase):
     def test_check_vmaster_ispr(self):
         self.errors_dict.update(EXPECTED_ERRORS_PR)
         self.errors_dict.update({
-            'manifest-version-format': 4,
             'missing-manifest-dependency': 2,
             'missing-import-error': 2,
         })
@@ -289,7 +288,6 @@ class MainTest(unittest.TestCase):
     def test_check_v8_ispr(self):
         self.errors_dict.update(EXPECTED_ERRORS_PR)
         self.errors_dict.update({
-            'manifest-version-format': 4,
             'missing-manifest-dependency': 2,
             'missing-import-error': 2,
         })
@@ -316,7 +314,6 @@ class MainTest(unittest.TestCase):
     def test_check_without_version_ispr(self):
         self.errors_dict.update(EXPECTED_ERRORS_PR)
         self.errors_dict.update({
-            'manifest-version-format': 4,
             'missing-manifest-dependency': 2,
             'missing-import-error': 2,
         })
@@ -341,4 +338,5 @@ class MainTest(unittest.TestCase):
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(MainTest)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())


### PR DESCRIPTION
[FIX] .travis.yml: Fix false red for stable branches, forcing PR flag
[FIX] self_tests: Returns exit code with the result of the tests

Currently there is a error with the dictionary expected but is not visible because show a false green.
Other issue is that the travis result of the branch stable is red because the flag of PR was off.