### PR TITLE
[FIX][travis] 'by_msg' key & .gitignore

### DIFF
--- a/sample_files/.gitignore
+++ b/sample_files/.gitignore
@@ -42,9 +42,8 @@ coverage.xml
 *.mo
 *.pot
 
-# IDEs
+# Pycharm
 .idea
-.vscode
 
 # Eclipse
 .settings

--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -214,7 +214,7 @@ def get_count_fails(linter_stats, msgs_no_count=None):
     """
     return sum([
         linter_stats['by_msg'][msg]
-        for msg in linter_stats['by_msg']
+        for msg in (linter_stats.get('by_msg') or {})
         if msg not in msgs_no_count])
 
 


### PR DESCRIPTION
First of all, in PR https://github.com/OCA/maintainer-quality-tools/pull/518 I forgot to the remove the **repeated** `.vcode` put by @Yajo in PR https://github.com/OCA/maintainer-quality-tools/pull/519.

And secondly, in PR https://github.com/OCA/maintainer-quality-tools/pull/526 I forgot to check the `get_count_fails` method that also uses `'by_msg'` key.

I hope I don't forget anything else  :grimacing: