### PR TITLE
[FIX] adapt behavior to docs

### DIFF
--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -121,7 +121,7 @@ def get_modules_cmd(dir):
 
 
 def version_validate(version, dir):
-    if version == "" and dir:
+    if not version and dir:
         repo_path = os.path.join(dir, '.git')
         branch_name = GitRun(repo_path).get_branch_name()
         version = (branch_name.replace('_', '-').split('-')[:1]

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -52,7 +52,7 @@ import travis_helpers
 git_work_dir = os.environ.get('TRAVIS_BUILD_DIR', False)
 is_pull_request = os.environ.get(
     'TRAVIS_PULL_REQUEST', 'false') != 'false'
-version = os.environ.get('VERSION', False)
+version = os.environ.get('VERSION', '')
 beta_msgs = run_pylint.get_beta_msgs()
 expected_errors = int(os.environ.get('PYLINT_EXPECTED_ERRORS', 0))
 exit_status = 0


### PR DESCRIPTION
in order to get the version autodetection the docs claim at the end of https://github.com/hbrunn/maintainer-quality-tools/blob/be6e4222c98128950c61bfad1b1ec64706f86a44/git/README.md, we need to pass an empty string to https://github.com/hbrunn/maintainer-quality-tools/blob/be6e4222c98128950c61bfad1b1ec64706f86a44/travis/run_pylint.py#L124

I don't really see the point of checking against the empty string there, maybe we should just check for falsyness?