### PR TITLE
[ADD] gengo library in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pyopenssl>=16.2.0
 pyyaml
 coveralls
 unittest2
+gengo
 
 configparser
 


### PR DESCRIPTION
`base_gengo` module uses this library and Odoo doesn't have put in their requirements file (yet).