### PR TITLE
[IMP] test_server: update test modules instead if they were preinstalled

### DIFF
--- a/travis/travis_transifex.py
+++ b/travis/travis_transifex.py
@@ -125,7 +125,7 @@ def main(argv=None):
     # Install the modules on the database
     database = "openerp_i18n"
     script_name = get_server_script(server_path)
-    setup_server(database, odoo_unittest, addons, server_path, script_name,
+    setup_server(database, odoo_unittest, addons_list, server_path, script_name,
                  addons_path, install_options, addons_list)
 
     # Initialize Transifex project


### PR DESCRIPTION
Check which modules are preinstalled. If some test modules were preinstalled, then they will be updated in the tests instead of installed.