### PR TITLE
[REF] sample_files: .travis.yml - Higher postgresql version

### DIFF
--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -9,6 +9,10 @@ python:
   - "2.7.13"
 
 addons:
+  # By default postgresql-9.1 is installed but there is issue related:
+  #  https://github.com/OCA/maintainer-quality-tools/issues/432#issuecomment-281580935
+  # Better use higher PostgreSQL version
+  postgresql: "9.4"
   apt:
 #    sources:
 #    Search your sources alias here:

--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -12,7 +12,7 @@ addons:
   # By default postgresql-9.1 is installed but there is issue related:
   #  https://github.com/OCA/maintainer-quality-tools/issues/432#issuecomment-281580935
   # Better use higher PostgreSQL version
-  postgresql: "9.4"
+  postgresql: "9.5"
   apt:
 #    sources:
 #    Search your sources alias here:


### PR DESCRIPTION
 * By default postgresql-9.1 is installed but there is issue related:
    - https://github.com/OCA/maintainer-quality-tools/issues/432#issuecomment-281580935
 * Better use higher PostgreSQL version

Continuation from https://github.com/OCA/maintainer-quality-tools/pull/538