### PR TITLE
Using TRAVIS_BUILD_DIR variable instead of hardcoded path

### DIFF
--- a/cfg/.coveragerc
+++ b/cfg/.coveragerc
@@ -2,7 +2,7 @@
 
 [report]
 include =
-    */build/*
+    ${TRAVIS_BUILD_DIR}/*
 
 omit =
     */scenario/*


### PR DESCRIPTION
When using MQT outside of travis the hardcoded /build/ dir of Travis is causing an issue by looking in the wrong place.

This offers a more flexible way to check the code that needs to be tested because even in gitlab we can define the TRAVIS_BUILD_DIR.

Downside is that if someone places other pieces of code in the /build/ dir next to the project they will be ignored (if that was ever the plan).

A better way would be to use a separate env var and handle default values but that might introduce new dependencies (such as envsusbt and such)

Close https://github.com/OCA/l10n-spain/pull/848