### PR TITLE
[ADD] exclude examples directory

### DIFF
--- a/travis/cfg/travis_run_flake8.cfg
+++ b/travis/cfg/travis_run_flake8.cfg
@@ -5,4 +5,4 @@
 # W503 changed by W504 and OCA prefers allow both
 ignore = E123,E133,E226,E241,E242,F811,F601,W503,W504
 max-line-length = 79
-exclude = __unported__,__init__.py
+exclude = __unported__,__init__.py,examples

--- a/travis/cfg/travis_run_flake8__init__.cfg
+++ b/travis/cfg/travis_run_flake8__init__.cfg
@@ -4,6 +4,6 @@
 # F999 pylint support this case with expected tests
 ignore = E123,E133,E226,E241,E242,F401,F601
 max-line-length = 79
-exclude = __unported__
+exclude = __unported__,examples
 filename = __init__.py
 


### PR DESCRIPTION
this makes the flake8 call ignore files in the examples directory as pylint-odoo does. Fixes OCA/pylint-odoo#193