### PR TITLE
[FIX] *: Fix typos and grammatical errors

### DIFF
--- a/travis/cfg/travis_run_pylint_exclude_61.cfg
+++ b/travis/cfg/travis_run_pylint_exclude_61.cfg
@@ -1,5 +1,5 @@
-# This config file not is a real pylint config file.
-# This file overwrite params of base template.
+# This config file is not a real pylint config file.
+# This file overwrites params of base template.
 
 [ODOOLINT]
 manifest_deprecated_keys=

--- a/travis/cfg/travis_run_pylint_exclude_70.cfg
+++ b/travis/cfg/travis_run_pylint_exclude_70.cfg
@@ -1,4 +1,4 @@
-# This config file not is a real pylint config file.
+# This config file is not a real pylint config file.
 # This file overwrite params of base template.
 
 [ODOOLINT]

--- a/travis/cfg/travis_run_pylint_pr.cfg
+++ b/travis/cfg/travis_run_pylint_pr.cfg
@@ -1,6 +1,6 @@
-# Used to check enabled messages on this file just in modules
+# Used to check enabled messages on this file only in modules
 #  changed in a pull request of the project.
-#  The result affect your build status.
+#  The result affects your build status.
 
 [MASTER]
 profile=no

--- a/travis/odoo_connection.py
+++ b/travis/odoo_connection.py
@@ -59,7 +59,7 @@ class _OdooBaseContext(object):
 
 
 class Odoo10Context(_OdooBaseContext):
-    """A context for connecting to a odoo 10 server with function to export
+    """A context for connecting to an odoo 10 server with function to export
     .pot files.
     """
 
@@ -99,7 +99,7 @@ class Odoo10Context(_OdooBaseContext):
 
 
 class Odoo11Context(Odoo10Context):
-    """A context for connecting to a odoo 11 server with an special override
+    """A context for connecting to an odoo 11 server with a special override
     for getting translations with Python 3.
     """
     def get_pot_contents(self, addon, lang=None):
@@ -116,7 +116,7 @@ class Odoo11Context(Odoo10Context):
 
 class Odoo8Context(_OdooBaseContext):
     """
-    A context for connecting to a odoo 8 server with function to export .pot
+    A context for connecting to an odoo 8 server with function to export .pot
     """
 
     def __enter__(self):
@@ -156,7 +156,7 @@ class Odoo8Context(_OdooBaseContext):
 
 class Odoo7Context(_OdooBaseContext):
     """
-    A context for connecting to a odoo 7 server with function to export .pot
+    A context for connecting to an odoo 7 server with function to export .pot
     """
 
     def __enter__(self):

--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -26,9 +26,9 @@ CLICK_DIR = click.Path(exists=True, dir_okay=True, resolve_path=True)
 def get_extra_params(odoo_version):
     """Get extra pylint params by odoo version
     Transform a seudo-pylint-conf to params,
-    it to overwrite base-pylint-conf values.
+    to overwrite base-pylint-conf values.
     Use a seudo-inherit of configuration file.
-    To avoid have a 2 config files (stable and pr-conf) by each odoo-version
+    To avoid having 2 config files (stable and pr-conf) by each odoo-version
     Example:
 
         pylint_master.conf
@@ -43,8 +43,8 @@ def get_extra_params(odoo_version):
         pylint_61_pr.conf
         ... and new future versions.
 
-    If you need add a new conventions in all versions
-    you will need change all pr files or stables files.
+    If you need to add new conventions in all versions,
+    you will need to change all pr files or stable files.
 
 
     With this method you can use:
@@ -54,10 +54,10 @@ def get_extra_params(odoo_version):
         pylint_disabling_70.conf <- Overwrite params of pylint_lastest*.conf
         pylint_disabling_61.conf <- Overwrite params of pylint_lastest*.conf
 
-    If you need add a new conventions in all versions you will need change just
-    pylint_lastest_pr.conf or pylint_lastest.conf, similar to inherit.
+    If you need to add new conventions in all versions, you will only need to
+    change pylint_lastest_pr.conf or pylint_lastest.conf, similar to inherit.
 
-    :param version: String with name of version of odoo
+    :param version: String to specify an Odoo's name or versio
     :return: List of extra pylint params
     """
     is_version_number = re.match(r'\d+\.\d+', odoo_version)
@@ -174,7 +174,7 @@ def pylint_run(is_pr, version, dir):
     print (count_info)
     if is_pr:
         print(travis_helpers.green(
-            'Start lint check just in modules changed'))
+            'Starting lint check only for modules changed'))
         modules_changed = get_modules_changed(dir, branch_base)
         if not modules_changed:
             print(travis_helpers.green(
@@ -220,7 +220,7 @@ def get_count_fails(linter_stats, msgs_no_count=None):
 
 def is_installable_module(path):
     """return False if the path doesn't contain an installable odoo module,
-    and the full path to the module manifest otherwise"""
+    otherwise the full path to the module's manifest"""
     manifest_path = is_module(path)
     if manifest_path:
         manifest = ast.literal_eval(open(manifest_path).read())
@@ -231,7 +231,7 @@ def is_installable_module(path):
 
 def get_subpaths(paths, depth=1):
     """Get list of subdirectories
-    if `__init__.py` file not exists in root path then
+    if `__init__.py` file doesn't exists in root path, then
     get subdirectories.
     Why? More info here:
         https://www.mail-archive.com/code-quality@python.org/msg00294.html
@@ -257,10 +257,10 @@ def get_subpaths(paths, depth=1):
 
 def run_pylint(paths, cfg, beta_msgs=None, sys_paths=None, extra_params=None):
     """Execute pylint command from original python library
-    :param paths: List of paths of python modules to check pylint
+    :param paths: List of paths of python modules to check with pylint
     :param cfg: String name of pylint configuration file
     :param sys_paths: List of paths to append to sys path
-    :param extra_params: List of parameters extra to append
+    :param extra_params: List of extra parameters to append
         in pylint command
     :return: Dict with python linter stats
     """
@@ -300,7 +300,7 @@ def main(paths, config_file, msgs_no_count=None,
     """Script to run pylint command with additional params
     to check fails of odoo modules.
     If expected errors is equal to count fails found then
-    this program exit with zero otherwise exit with counted fails"""
+    this program exits with zero, otherwise exits with counted fails"""
     try:
         stats = run_pylint(
             list(paths), config_file.name,

--- a/travis/test_pylint
+++ b/travis/test_pylint
@@ -14,26 +14,26 @@ Use the following types of pylint configuration files:
 1) Global
 
   Used to check enabled messages on this file in all modules of the project.
-  The result affect your build status.
+  The result affects your build status.
   File name: `travis_run_pylint.cfg`
 
 
 2) Pull request
 
-  Used to check enabled messages on this file just in modules
+  Used to check enabled messages on this file only in modules
   changed in a pull request of the project.
   The result affects your build status.
   File name: `travis_run_pylint_pr.cfg`
 
 
-2) Version Exclusions
+3) Version Exclusions
 
-  Used to disable the previously enabled messages of `global` or `pull request`
+  Used to disable previously enabled messages on `global` or `pull request`
   configuration files based on `VERSION` variable environment.
   File name: `travis_run_pylint_exclude_{VERSION}.cfg`
 
 
-3) Beta
+4) Beta
 
   Used to add the previously enabled messages in `global` or `pull request`
   configuration files that you want to display, without affecting your build

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -111,7 +111,7 @@ def str2bool(string):
 
 def get_server_path(odoo_full, odoo_version, travis_home):
     """
-    Calculate server path
+    Computes server path
     :param odoo_full: Odoo repository path
     :param odoo_version: Odoo version
     :param travis_home: Travis home directory
@@ -126,7 +126,7 @@ def get_server_path(odoo_full, odoo_version, travis_home):
 
 def get_addons_path(travis_dependencies_dir, travis_build_dir, server_path):
     """
-    Calculate addons path
+    Computes addons path
     :param travis_dependencies_dir: Travis dependencies directory
     :param travis_build_dir: Travis build directory
     :param server_path: Server path
@@ -211,7 +211,7 @@ def setup_server(db, odoo_unittest, tested_addons, server_path, script_name,
                  unbuffer=True, server_options=None):
     """
     Setup the base module before running the tests
-    if the database template exists then will be used.
+    if the database template exists, then it will be used.
     :param db: Template database name
     :param odoo_unittest: Boolean for unit test (travis parameter)
     :param tested_addons: (list) Modules that need to be installed
@@ -249,7 +249,7 @@ def setup_server(db, odoo_unittest, tested_addons, server_path, script_name,
 
 
 def run_from_env_var(env_name_startswith, environ):
-    """Method to run a script defined from a environment variable
+    """Method to run a script defined from an environment variable
     :param env_name_startswith: String with name of first letter of
                                 environment variable to find.
     :param environ: Dictionary with full environ to search
@@ -438,9 +438,9 @@ def main(argv=None):
             if returncode != 0:
                 all_errors.append(to_test)
                 print(fail_msg, "Command exited with code %s" % returncode)
-                # If not exists errors then
-                # add an error when returcode!=0
-                # because is really a error.
+                # If there are no errors,
+                # adds an error when returcode!=0
+                # because it's actually an error.
                 if not errors:
                     errors += 1
             if errors:

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -20,7 +20,7 @@ if [ "${LINT_CHECK}" != "0" ]; then
     fi
 fi
 
-# We can exit here and do nothing if this only a LINT check
+# We can exit here and do nothing if this is only a LINT check
 if [ "${TESTS}" != "1" ] && [ "${LINT_CHECK}" == "1" ]; then
     exit 0
 fi
@@ -97,7 +97,7 @@ rm -f $VIRTUAL_ENV/lib/python2.7/no-global-site-packages.txt
 pip install --upgrade pip
 pip install -q --no-binary pycparser -r ${HOME}/maintainer-quality-tools/requirements.txt
 
-# Odoo <= 7.0 don't have requirements.txt file then the 8.0 file is used by default
+# Odoo <= 7.0 doesn't have requirements.txt file, then the 8.0 file is used by default
 if [ ! -f ${ODOO_PATH}/requirements.txt ]; then
     wget https://raw.githubusercontent.com/odoo/odoo/8.0/requirements.txt -O ${ODOO_PATH}/requirements.txt
 fi

--- a/travis/travis_weblate.py
+++ b/travis/travis_weblate.py
@@ -128,7 +128,7 @@ class TravisWeblateUpdate(object):
             for po_file_name in po_files:
                 lang = os.path.basename(os.path.splitext(po_file_name)[0])
                 if self._langs and lang not in self._langs:
-                    # Limit just allowed languages if is defined
+                    # Limit to only allowed languages if it's defined
                     continue
                 po_file_path = os.path.join(i18n_folder, po_file_name)
                 with open(po_file_path, 'r') as f_po:


### PR DESCRIPTION
This applies some minor fixes to comments and strings all over the
project, including typos, grammatical errors, etc.

For instance:
- It don't -> it doesn't
- A Odoo server -> An Odoo server
- You need add a new conventions -> You need to add new conventions