### PR TITLE
[FIX] install: Use compatible less version for odoo

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -28,6 +28,7 @@ fi
 
 # Install less
 ln -s `which nodejs` $HOME/maintainer-quality-tools/travis/node
+# Remove fixed version after fix https://github.com/odoo/odoo/issues/25632
 npm install -g less@3.0.4 less-plugin-clean-css
 
 if [ "${WEBSITE_REPO}" == "1" ]; then

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -28,7 +28,7 @@ fi
 
 # Install less
 ln -s `which nodejs` $HOME/maintainer-quality-tools/travis/node
-npm install -g less less-plugin-clean-css
+npm install -g less@3.0.4 less-plugin-clean-css
 
 if [ "${WEBSITE_REPO}" == "1" ]; then
     if [ -f ~/.rvm/scripts/rvm ]; then


### PR DESCRIPTION
More info about: https://github.com/odoo/odoo/issues/25632
Note: It is not a good idea pinned the version but currently we will have all our runbot's instances without connection


UPDATED:
You can see an example of the error connecting a recent build from our runbot:
 - https://runbot.odoo-community.org/runbot/226/11.0
