### PR TITLE
[UPD] Cleanup gitlab-ci file using python-3.5 image

### DIFF
--- a/sample_files/.gitlab-ci-2.yml
+++ b/sample_files/.gitlab-ci-2.yml
@@ -1,0 +1,66 @@
+image: python:3.5
+stages:
+  - test
+
+services:
+  - postgres:10
+
+variables:
+  POSTGRES_DB: project_ci_test
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: ""
+  TEST_DBNAME: '${CI_PROJECT_PATH_SLUG}-pipeline-${CI_PIPELINE_ID}'
+  DEPLOY_DBNAME: '${CI_PROJECT_PATH_SLUG}-${CI_COMMIT_REF_SLUG}'
+  RUNNER_HOME: '/home/gitlab-runner'
+  INSTANCE_PATH: '${RUNNER_HOME}/instances/${CI_PROJECT_PATH_SLUG}-${CI_COMMIT_REF_SLUG}'
+  TRAVIS_BUILD_DIR: "$CI_PROJECT_DIR"
+  VERSION: "11.0"
+  ODOO_BRANCH: "11.0"
+  ODOO_REPO: "odoo/odoo"
+
+
+before_script:
+  - curl -sL https://deb.nodesource.com/setup_10.x | bash -
+  - apt-get install -y  sudo postgresql-client expect-dev python-lxml nodejs python-dev python-pip build-essential libsasl2-dev python-dev libldap2-dev libssl-dev
+  - pip install coverage coveralls codecov
+
+lint:
+  stage: test
+  tags:
+    - postgres
+    - docker
+  variables:
+    LINT_CHECK: "1"
+    TESTS: "0"
+  script:
+    # We need to export the PG* here, otherwise the postgresql container
+    # Wil pick them up
+    - export PGHOST="postgres"
+    - export PGUSER="postgres"
+    - export PGPASSWORD=""
+    - git clone https://github.com/OCA/maintainer-quality-tools.git -b master ${HOME}/maintainer-quality-tools
+    - export PATH=${HOME}/maintainer-quality-tools/travis:${HOME}/gitlab_tools:${PATH}
+    - travis_install_nightly
+    - travis_run_tests
+    - travis_after_tests_success || true
+
+test:
+  stage: test
+  tags:
+    - postgres
+    - docker
+  variables:
+    LINT_CHECK: "0"
+    TESTS: "1"
+  script:
+    # We need to export the PG* here, otherwise the postgresql container
+    # Wil pick them up
+    - export PGHOST="postgres"
+    - export PGUSER="postgres"
+    - export PGPASSWORD=""
+    - git clone https://github.com/OCA/maintainer-quality-tools.git -b master ${HOME}/maintainer-quality-tools
+    - export PATH=${HOME}/maintainer-quality-tools/travis:${HOME}/gitlab_tools:${PATH}
+    - travis_install_nightly
+    - travis_run_tests
+    - travis_after_tests_success || true
+  coverage: '/TOTAL.+ ([0-9]{1,3}%)/'


### PR DESCRIPTION
This is, imho, a cleaner gitlab ci example.
Uses the docker python 3.5 image with an extra service dependency on the postgresql image. 

Testing can be done on the public shared gitlab runners, or private runners when needed.

An example where a public oca repository is tested can be found https://gitlab.com/road-support/oca-account-invoicing/
(It's currently failing because the codecoverage has gone down, test and lint check are green)