### PR TITLE
[FIX] Include six in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyopenssl>=16.2.0
 pyyaml
 coveralls
 unittest2
-
+six
 configparser
 
 # transifex requirements

--- a/travis/cfg/travis_run_pylint.cfg
+++ b/travis/cfg/travis_run_pylint.cfg
@@ -12,6 +12,8 @@ disable=all
 #   assignment-from-none - W1111
 #   dangerous-default-value - W0102
 #   duplicate-key - W0109
+#   missing-import-error - W7935
+#   missing-manifest-dependency - W7936
 #   pointless-statement - W0104
 #   pointless-string-statement - W0105
 #   print-statement - E1601

--- a/travis/cfg/travis_run_pylint_beta.cfg
+++ b/travis/cfg/travis_run_pylint_beta.cfg
@@ -13,12 +13,15 @@ disable=all
 #   attribute-deprecated - W8105
 #   class-camelcase - C8104
 #   create-user-wo-reset-password - W7905
+#   consider-merging-classes-inherited - R7980
 #   copy-wo-api-one - W8102
 #   dangerous-filter-wo-user - W7901
+#   dangerous-view-replace-wo-priority - W7940
 #   deprecated-module - W0402
 #   duplicate-id-csv - W7906
 #   duplicate-xml-fields - W7907
 #   duplicate-xml-record-id - W7902
+#   file-not-used - W7930
 #   incoherent-interpreter-exec-perm - W8201
 #   invalid-commit - E8102
 #   javascript-lint - W7903
@@ -31,6 +34,8 @@ disable=all
 #   missing-readme - C7902
 #   no-utf8-coding-comment - C8201
 #   unnecessary-utf8-coding-comment - C8202
+#   odoo-addons-relative-import - W7950
+#   old-api7-method-defined - R8110
 #   openerp-exception-warning - R8101
 #   redundant-modulename-xml - W7909
 #   sql-injection - E8103

--- a/travis/cfg/travis_run_pylint_exclude_61.cfg
+++ b/travis/cfg/travis_run_pylint_exclude_61.cfg
@@ -6,11 +6,15 @@ manifest_deprecated_keys=
 
 [MESSAGES CONTROL]
 # Disable message and code:
+#   api-one-deprecated - W8104
 #   attribute-deprecated - W8105
 #   copy-wo-api-one - W8102
 #   class-camelcase - C8104
 #   missing-readme - C7902
+#   old-api7-method-defined - R8110
 #   openerp-exception-warning - R8101
+#   missing-import-error - W7935
+#   missing-manifest-dependency - W7936
 
 disable=api-one-deprecated,
     attribute-deprecated,

--- a/travis/cfg/travis_run_pylint_exclude_70.cfg
+++ b/travis/cfg/travis_run_pylint_exclude_70.cfg
@@ -6,11 +6,15 @@ manifest_deprecated_keys=
 
 [MESSAGES CONTROL]
 # Disable message and code:
+#   api-one-deprecated - W8104
 #   attribute-deprecated - W8105
 #   copy-wo-api-one - W8102
 #   class-camelcase - C8104
 #   missing-readme - C7902
+#   old-api7-method-defined - R8110
 #   openerp-exception-warning - R8101
+#   missing-import-error - W7935
+#   missing-manifest-dependency - W7936
 
 disable=api-one-deprecated,
     attribute-deprecated,


### PR DESCRIPTION
It happens that `travis/git_run.py` and `travis/test_server.p`y use `six` library, but that library is not in `requirements.txt` file. Thus, this PR fixes that.

Also, as a bonus, I updated the disable message commented sections.