### PR TITLE
[FIX] self_tests: Adjust expected values after pylint change

### DIFF
--- a/travis/self_tests
+++ b/travis/self_tests
@@ -90,6 +90,7 @@ class MainTest(unittest.TestCase):
         self.modules_cmd = run_pylint.get_modules_cmd(self.git_work_dir)
         self.beta_msgs = run_pylint.get_beta_msgs()
         self.errors_dict = EXPECTED_ERRORS.copy()
+        self.maxDiff = None
 
     def test_modules_to_preinstall(self):
         res = [x for x in self.to_preinstall if x in self.addons_list]
@@ -286,6 +287,9 @@ class MainTest(unittest.TestCase):
     @unittest.skipIf(os.environ.get('LINT_CHECK', 0) != '1', "Set LINT_CHECK")
     def test_check_v7_ispr(self):
         self.errors_dict.update(EXPECTED_ERRORS_PR)
+        self.errors_dict.update({
+            'manifest-version-format': 6,
+        })
 
         with _patch_streams(StringIO()):
             result = run_pylint.pylint_run(


### PR DESCRIPTION
In a recent change on pylint-odoo [1], it was introduced a fix to
recognize a badly-formatted version in manifest, which now depends on
the Odoo version. When the version is provided and it's a numeric
version value (e.g. not "master") it's taken into account to determine
whether the version defined in the manifest is formatted correctly.

Since versions in tested modules are as follows:
- Two set to 8.0
- Four set to wrong values (e.g. 1.0)

When the version is numeric but it's not 8.0, there will be six errors,
otherwise there will be four. In these tests, the only case when it's
numeric but it's not 8.0, is when testing 7.0.

[1] Pylint change: https://github.com/OCA/pylint-odoo/commit/6b1f1e1bfaf