### PR TITLE
[IMP] test_server: Patch odoo to create unlogged DB tables (#283)

### DIFF
--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -290,6 +290,31 @@ def copy_attachments(dbtemplate, dbdest, data_dir):
         shutil.copytree(attach_tmpl_dir, attach_dest_dir)
 
 
+def patch_odoo_unlogged_tables(server_path):
+    """Patch Odoo to  make it to create all DB tables as unlogged"""
+    print("Patching Odoo to create DB tables as unlogged...")
+    filenames_to_patch = [
+        'addons/base/base.sql',
+        'addons/base/data/base_data.sql',
+        'fields.py',
+        'models.py',
+        'tools/sql.py',
+        'osv/orm.py',
+    ]
+    odoo_subdir = "odoo" if os.path.isdir(
+        os.path.join(server_path, "odoo")) else "openerp"
+    for filename in filenames_to_patch:
+        filename = os.path.join(server_path, odoo_subdir, filename)
+        if not os.path.isfile(filename):
+            continue
+        with open(filename) as f_to_patch:
+            if not re.search("create table", f_to_patch.read(), re.IGNORECASE):
+                continue
+        print("\tPatching file %s" % filename)
+        subprocess.call(
+            ["sed", "-i", "s/CREATE TABLE/CREATE UNLOGGED TABLE/gI", filename])
+
+
 def main(argv=None):
     if argv is None:
         argv = sys.argv
@@ -308,6 +333,8 @@ def main(argv=None):
     odoo_branch = os.environ.get("ODOO_BRANCH")
     instance_alive = str2bool(os.environ.get('INSTANCE_ALIVE'))
     unbuffer = str2bool(os.environ.get('UNBUFFER', True))
+    is_runbot = str2bool(os.environ.get('RUNBOT'))
+    is_gitlab_ci = str2bool(os.environ.get('GITLAB_CI'))
     data_dir = os.path.expanduser(os.environ.get("DATA_DIR", '~/data_dir'))
     test_enable = str2bool(os.environ.get('TEST_ENABLE', True))
     dbtemplate = os.environ.get('MQT_TEMPLATE_DB', 'openerp_template')
@@ -333,6 +360,8 @@ def main(argv=None):
     odoo_full = os.environ.get("ODOO_REPO", "odoo/odoo")
     server_path = get_server_path(odoo_full, odoo_branch or odoo_version,
                                   travis_home)
+    if is_runbot or is_gitlab_ci:
+        patch_odoo_unlogged_tables(server_path)
     script_name = get_server_script(server_path)
     addons_path = get_addons_path(travis_dependencies_dir,
                                   travis_build_dir,


### PR DESCRIPTION
This commit causes Odoo to be patched so all database tables are created
as unlogged.

This is applied only for testing instances because, if a docker
container is stopped without firstly saving the changes, all records
will be deleted; so it's not suitable for working under other
environments, e.g. locally.

This is compatible with the versions 7.0 to master (12.0).