### PR TITLE
[REF] requirements: Supports new frontend unittest engine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,14 @@ matrix:
       env:
         VERSION="11.0" ODOO_REPO="OCA/OCB" TESTS="1" LINT_CHECK="0"
         INCLUDE="test_module,second_module"
+    - python: 3.5
+      env:
+        VERSION="12.0" ODOO_REPO="OCA/OCB" TESTS="1" LINT_CHECK="0"
+        INCLUDE="test_module,second_module"
+    - python: 3.7-dev
+      env:
+        VERSION="12.0" ODOO_REPO="OCA/OCB" TESTS="1" LINT_CHECK="0"
+        INCLUDE="test_module,second_module"
 
 install:
   - cp -r ../maintainer-quality-tools/ $HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
     - $HOME/.cache/pip
 
 addons:
+  postgresql: "9.5"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
     - $HOME/.cache/pip
 
 addons:
-  postgresql: "9.5"
+  postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pyserial
 pyopenssl>=16.2.0
 pyyaml
 coveralls
+websocket-client
 unittest2
 
 configparser


### PR DESCRIPTION
Fix the following warning:
 - websocket-client module is not installed

More info about:
https://github.com/OCA/e-commerce/pull/250
https://travis-ci.org/OCA/e-commerce/jobs/436197303#L1456


Add 12.0 environment in order to detect this kind of errors early.
