### PR TITLE
[FIX] never break for decoding errors in log

### DIFF
--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -430,7 +430,9 @@ def main(argv=None):
             with open('stdout.log', 'wb') as stdout:
                 for line in iter(pipe.stdout.readline, b''):
                     stdout.write(line)
-                    print(line.strip().decode('UTF-8'))
+                    print(line.strip().decode(
+                        'UTF-8', errors='backslashreplace'
+                    ))
             returncode = pipe.wait()
             # Find errors, except from failed mails
             errors = has_test_errors(


### PR DESCRIPTION
in https://github.com/Therp/Therp-Addons, I have a [test](https://github.com/Therp/Therp-Addons/blob/10.0/fetchmail_inbox/tests/test_fetchmail_inbox.py#L18) that calls `mail.thread#message_process` with Odoo's [test mails](https://github.com/OCA/OCB/blob/10.0/addons/mail/tests/test_mail_gateway.py#L70) from the mail module. Note those contain non-ascii characters, and the mail module logs the sender.

I spent today to debug the fact that this test never finishes, actually, the build just dies as in https://travis-ci.org/Therp/Therp-Addons/jobs/482456801#L1271 - after quite some questioning my sanity, I understood this is neither Odoo breaking nor the test, but the test script itself. This should never happen in my opinion, whatever garbage Odoo logs, we need to be able to deal with it.

Note I fixed my build by muting the logger, but that's not a general solution.