### PR TITLE
[FIX] requirements: improve python3 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 simplejson
 pyserial
 pyopenssl>=16.2.0
-pyyaml
+pyyaml==3.12 ; python_version < '3.7'
+pyyaml==3.13 ; python_version >= '3.7'
 six
 coveralls
 websocket-client


### PR DESCRIPTION
Same as https://github.com/odoo/odoo/commit/8bda4744b5a2d6faa5e6900bdbaade460b7e1a6b.

This PR tries to greenify the maintainer-quality-tools repo. The broken analysis are:

![Selection_054](https://user-images.githubusercontent.com/25005517/54844053-2e006180-4cd6-11e9-8e00-1c1afead27a9.png)
