### PR TITLE
[REF] travis_run_flake8.cfg: disable E203 whitespace before ':'

### DIFF
--- a/travis/cfg/travis_run_flake8.cfg
+++ b/travis/cfg/travis_run_flake8.cfg
@@ -3,6 +3,7 @@
 # F811 is legal in odoo 8 when we implement 2 interfaces for a method
 # F999 pylint support this case with expected tests
 # W503 changed by W504 and OCA prefers allow both
-ignore = E123,E133,E226,E241,E242,F811,F601,W503,W504
+# E203: whitespace before ':' (black behaviour and not pep8 compliant)
+ignore = E123,E133,E226,E241,E242,F811,F601,W503,W504,E203
 max-line-length = 79
 exclude = __unported__,__init__.py,examples


### PR DESCRIPTION
E203 is not PEP 8 compliant, we should tell Flake8 to ignore these warnings. https://www.python.org/dev/peps/pep-0008/#whitespace-in-expressions-and-statements
This change allows us to use MQT on code formatted by black and thus opens the door to the use of this tool on OCA repositories.