### PR TITLE
[FIX] travis_run_flake8.cfg: do not fully ignore __init__.py

### DIFF
--- a/travis/cfg/travis_run_flake8.cfg
+++ b/travis/cfg/travis_run_flake8.cfg
@@ -6,4 +6,6 @@
 # E203: whitespace before ':' (black behaviour and not pep8 compliant)
 ignore = E123,E133,E226,E241,E242,F811,F601,W503,W504,E203
 max-line-length = 79
-exclude = __unported__,__init__.py,examples
+exclude = __unported__,examples
+per-file-ignores =
+  **/__init__.py:F401


### PR DESCRIPTION
The only rule that has to be ignored in __init__.py is F401: https://lintlyci.github.io/Flake8Rules/rules/F401.html
All other rules must be validated in __init__.py files as those are also used to define pre-init hooks and other validations.