### PR TITLE
[REF] travis_run_flake8.cfg: Use B950 instead of E510

### DIFF
--- a/travis/cfg/travis_run_flake8.cfg
+++ b/travis/cfg/travis_run_flake8.cfg
@@ -4,6 +4,9 @@
 # F999 pylint support this case with expected tests
 # W503 changed by W504 and OCA prefers allow both
 # E203: whitespace before ':' (black behaviour and not pep8 compliant)
-ignore = E123,E133,E226,E241,E242,F811,F601,W503,W504,E203
+# E501: Having to change the code for just 1 extra character is too restrictive
+# B950: Use this warning instead of E501
+select = C,E,F,W,B,B950
+ignore = E123,E133,E226,E241,E242,F811,F601,W503,W504,E203,E501
 max-line-length = 79
 exclude = __unported__,__init__.py,examples


### PR DESCRIPTION
As explained in: https://github.com/PyCQA/flake8-bugbear#how-to-enable-opinionated-warnings

B950: Line too long. This is a pragmatic equivalent of pycodestyle's E501: it considers "max-line-length" but only triggers when the value has been exceeded by more than 10%. You will no longer be forced to reformat code due to the closing parenthesis being one character too far to satisfy the linter. At the same time, if you do significantly violate the line length, you will receive a message that states what the actual limit is. This is inspired by Raymond Hettinger's "Beyond PEP 8" talk and highway patrol not stopping you if you drive < 5mph too fast. Disable E501 to avoid duplicate warnings.