### PR TITLE
[REF] install: pin coveralls version and supporting broken_uninstallable module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,10 +57,12 @@ matrix:
       env:
         VERSION="12.0" ODOO_REPO="OCA/OCB" TESTS="1" LINT_CHECK="0"
         INCLUDE="test_module,second_module"
+        SERVER_EXPECTED_ERRORS="1"  # Supporting broken_uninstallable module after https://github.com/odoo/odoo/commit/c5d6a39
     - python: 3.7-dev
       env:
         VERSION="12.0" ODOO_REPO="OCA/OCB" TESTS="1" LINT_CHECK="0"
         INCLUDE="test_module,second_module"
+        SERVER_EXPECTED_ERRORS="1"  # Supporting broken_uninstallable module after https://github.com/odoo/odoo/commit/c5d6a39
 
 install:
   - cp -r ../maintainer-quality-tools/ $HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ install:
   - cp -r tests/test_repo/* ./
   - export PATH=$HOME/maintainer-quality-tools/travis:$PATH
    # Force install lint requirements in all cases of MQT for self_test script.
-  - pip install codecov coveralls
+  - pip install codecov==2.0.15 coveralls==1.8.2
   - LINT_CHECK="1" travis_install_nightly 8.0 # only used if VERSION not set in env
   - git --git-dir=${TRAVIS_BUILD_DIR}/.git add --all  # All modules moved are modules changed to test PR changes
 

--- a/sample_files/.gitlab-ci-2.yml
+++ b/sample_files/.gitlab-ci-2.yml
@@ -22,7 +22,7 @@ variables:
 before_script:
   - curl -sL https://deb.nodesource.com/setup_10.x | bash -
   - apt-get install -y  sudo postgresql-client expect-dev python-lxml nodejs python-dev python-pip build-essential libsasl2-dev python-dev libldap2-dev libssl-dev
-  - pip install coverage coveralls codecov
+  - pip install codecov==2.0.15 coveralls==1.8.2 coverage
 
 lint:
   stage: test

--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -108,7 +108,7 @@ sed -i '/^python-ldap\=\=/d' ${ODOO_PATH}/requirements.txt
 sed -i 's/^requests\=\=/requests[security]\=\=/g' ${ODOO_PATH}/requirements.txt
 
 pip install -q --no-binary pycparser -r ${ODOO_PATH}/requirements.txt
-pip install -q QUnitSuite coveralls codecov
+pip install -q QUnitSuite codecov==2.0.15 coveralls==1.8.2
 
 # Use reference .coveragerc
 cp ${HOME}/maintainer-quality-tools/cfg/.coveragerc .


### PR DESCRIPTION
Related with https://github.com/OCA/maintainer-quality-tools/issues/626
cc @Yajo 


And Supporting broken_uninstallable module
After new logger.error from https://github.com/odoo/odoo/commit/c5d6a39
