### PR TITLE
Update eslintrc configuration

### DIFF
--- a/sample_files/pre-commit-13.0/.eslintrc.yml
+++ b/sample_files/pre-commit-13.0/.eslintrc.yml
@@ -5,56 +5,74 @@ env:
 parserOptions:
   ecmaVersion: 2017
 
-# Globals available in Odoo that shouldn't produce warnings
+# Globals available in Odoo that shouldn't produce errorings
 globals:
-  $: false
-  _: false
-  fuzzy: false
-  jQuery: false
-  moment: false
-  Promise: false
-  odoo: false
-  openerp: false
+  _: readonly
+  $: readonly
+  fuzzy: readonly
+  jQuery: readonly
+  moment: readonly
+  odoo: readonly
+  openerp: readonly
+  Promise: readonly
 
 # Styling is handled by Prettier, so we only need to enable AST rules;
 # see https://github.com/OCA/maintainer-quality-tools/pull/618#issuecomment-558576890
 rules:
+  accessor-pairs: warn
+  array-callback-return: warn
+  callback-return: warn
+  capitalized-comments:
+    - warn
+    - always
+    - ignoreConsecutiveComments: true
+      ignoreInlineComments: true
+  complexity:
+    - warn
+    - 15
+  constructor-super: warn
+  dot-notation: warn
+  eqeqeq: warn
+  global-require: warn
+  handle-callback-err: warn
+  id-blacklist: warn
+  id-match: warn
+  init-declarations: error
+  max-depth: warn
+  max-nested-callbacks: warn
+  max-statements-per-line: warn
   no-alert: warn
   no-array-constructor: warn
   no-caller: warn
   no-case-declarations: warn
-  no-catch-shadow: warn
   no-class-assign: warn
-  no-cond-assign: warn
-  no-confusing-arrow: warn
-  no-const-assign: warn
+  no-cond-assign: error
+  no-const-assign: error
   no-constant-condition: warn
   no-control-regex: warn
-  no-debugger: warn
+  no-debugger: error
   no-delete-var: warn
   no-div-regex: warn
-  no-dupe-args: warn
-  no-dupe-class-members: warn
-  no-dupe-keys: warn
-  no-duplicate-case: warn
-  no-duplicate-imports: warn
+  no-dupe-args: error
+  no-dupe-class-members: error
+  no-dupe-keys: error
+  no-duplicate-case: error
+  no-duplicate-imports: error
   no-else-return: warn
-  no-empty: warn
   no-empty-character-class: warn
-  no-empty-function: warn
-  no-empty-pattern: warn
-  no-eq-null: warn
-  no-eval: warn
-  no-ex-assign: warn
+  no-empty-function: error
+  no-empty-pattern: error
+  no-empty: warn
+  no-eq-null: error
+  no-eval: error
+  no-ex-assign: error
   no-extend-native: warn
   no-extra-bind: warn
   no-extra-boolean-cast: warn
   no-extra-label: warn
-  no-extra-parens: warn
-  no-extra-semi: warn
   no-fallthrough: warn
-  no-floating-decimal: warn
-  no-func-assign: warn
+  no-func-assign: error
+  no-global-assign: error
   no-implicit-coercion:
     - warn
     - allow: ["~"]
@@ -63,27 +81,26 @@ rules:
   no-inline-comments: warn
   no-inner-declarations: warn
   no-invalid-regexp: warn
+  no-irregular-whitespace: warn
   no-iterator: warn
   no-label-var: warn
   no-labels: warn
   no-lone-blocks: warn
-  no-lonely-if: warn
-  no-mixed-operators: warn
-  no-mixed-requires: warn
+  no-lonely-if: error
+  no-mixed-requires: error
   no-multi-str: warn
-  no-multiple-empty-lines: warn
-  no-native-reassign: warn
+  no-native-reassign: error
   no-negated-condition: warn
-  no-negated-in-lhs: warn
-  no-new: warn
+  no-negated-in-lhs: error
   no-new-func: warn
   no-new-object: warn
   no-new-require: warn
   no-new-symbol: warn
   no-new-wrappers: warn
+  no-new: warn
   no-obj-calls: warn
-  no-octal: warn
   no-octal-escape: warn
+  no-octal: warn
   no-param-reassign: warn
   no-path-concat: warn
   no-process-env: warn
@@ -96,29 +113,27 @@ rules:
   no-restricted-imports: warn
   no-restricted-modules: warn
   no-restricted-syntax: warn
-  no-return-assign: warn
+  no-return-assign: error
   no-script-url: warn
   no-self-assign: warn
   no-self-compare: warn
   no-sequences: warn
-  no-shadow: warn
   no-shadow-restricted-names: warn
+  no-shadow: warn
   no-sparse-arrays: warn
   no-sync: warn
-  no-tabs: warn
   no-this-before-super: warn
   no-throw-literal: warn
-  no-undef: warn
   no-undef-init: warn
-  no-unexpected-multiline: warn
+  no-undef: error
   no-unmodified-loop-condition: warn
-  no-unneeded-ternary: warn
-  no-unreachable: warn
-  no-unsafe-finally: warn
-  no-unused-expressions: warn
-  no-unused-labels: warn
-  no-unused-vars: warn
-  no-use-before-define: warn
+  no-unneeded-ternary: error
+  no-unreachable: error
+  no-unsafe-finally: error
+  no-unused-expressions: error
+  no-unused-labels: error
+  no-unused-vars: error
+  no-use-before-define: error
   no-useless-call: warn
   no-useless-computed-key: warn
   no-useless-concat: warn
@@ -127,49 +142,14 @@ rules:
   no-useless-rename: warn
   no-void: warn
   no-with: warn
-  array-callback-return: warn
-  accessor-pairs: warn
-  callback-return: warn
-  capitalized-comments:
-    - warn
-    - always
-    - ignoreConsecutiveComments: true
-      ignoreInlineComments: true
-  complexity:
-    - warn
-    - 15
-  constructor-super: warn
-  curly: warn
-  dot-location:
-    - warn
-    - property
-  dot-notation: warn
-  eol-last: warn
-  eqeqeq: warn
-  global-require: warn
-  handle-callback-err: warn
-  id-blacklist: warn
-  id-match: warn
-  init-declarations: warn
-  jsx-quotes: warn
-  max-depth: warn
-  max-nested-callbacks: warn
-  max-statements-per-line: warn
-  new-parens: warn
-  operator-assignment: warn
-  operator-linebreak: warn
+  operator-assignment: [error, always]
   prefer-const: warn
   radix: warn
   require-yield: warn
   sort-imports: warn
-  spaced-comment:
-    - warn
-    - always
-  strict:
-    - warn
-    - function
-  unicode-bom: warn
-  use-isnan: warn
+  spaced-comment: [error, always]
+  strict: [error, function]
+  use-isnan: error
   valid-jsdoc:
     - warn
     - prefer:
@@ -197,6 +177,4 @@ rules:
       requireReturnDescription: false
       requireReturnType: false
   valid-typeof: warn
-  wrap-iife: warn
-  wrap-regex: warn
   yoda: warn


### PR DESCRIPTION
- Sort file alphabetically to make maintenance easier
- Remove more rules disabled in https://github.com/prettier/eslint-config-prettier/blob/v6.9.0/index.js
- Remove `false` and put `readonly` in globals; [`false` is deprecated](https://eslint.org/docs/user-guide/configuring#specifying-globals)
- All failures were tagged as warn because until today, pylint-odoo only printed warnings in JS files. IMHO it's time to flip the switch, so I manually enabled some checks as errors.

@Tecnativa TT20357