### PR TITLE
[IMP] Use verbose colored pre-commit in CI

### DIFF
--- a/sample_files/.travis.yml
+++ b/sample_files/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       name: "pre-commit"
       python: "3.6"  # Black requires python >= 3.6
       install: pip install pre-commit
-      script: pre-commit run --all --show-diff-on-failure
+      script: pre-commit run --all --show-diff-on-failure --verbose --color always
       after_success:
       before_install:
     # use this linting job for repos that do not use pre-commit (default for < 13)


### PR DESCRIPTION
After https://github.com/OCA/maintainer-quality-tools/pull/630, some linters like eslint may produce warnings that would be unnoticed if no errors were found.

To be able to still see the warnings, I add `--verbose` to pre-commit.

Also, I add the handful `--color always` to make colored output even without a TTy, as it was the case.

@Tecnativa TT20357