### PR TITLE
Ignore `lib/` wherever it stays

### DIFF
--- a/sample_files/pre-commit-13.0/.pre-commit-config.yaml
+++ b/sample_files/pre-commit-13.0/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: |
   # Maybe reactivate this when all README files include prettier ignore tags?
   ^README\.md$|
   # Library files can have extraneous formatting (even minimized)
-  /static/(src/)?lib/|
+  lib/|
   # Repos using Sphinx to generate docs don't need prettying
   ^docs/_templates/.*\.html$|
   # You don't usually want a bot to modify your legal texts


### PR DESCRIPTION
Libs can be place in several paths depending on project's needs.
We should always ignore them.