### PR TITLE
[FIX] do not set addons_path when installing with pip

### DIFF
--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -338,7 +338,8 @@ def main(argv=None):
                                   travis_build_dir,
                                   server_path)
     create_server_conf({
-        'addons_path': addons_path,
+        # when installing with pip we don't need an addons_path
+        'addons_path': addons_path if os.environ.get("MQT_DEP", "OCA") == "OCA" else "",
         'data_dir': data_dir,
     }, odoo_version)
     tested_addons_list = get_addons_to_check(travis_build_dir,
@@ -471,12 +472,12 @@ def main(argv=None):
         and os.environ.get('TRAVIS_REPO_SLUG', '').startswith('OCA/')
         and (
             os.environ.get('TRAVIS_BRANCH')
-            in ('8.0', '9.0', '10.0', '11.0', '12.0', '13.0') 
+            in ('8.0', '9.0', '10.0', '11.0', '12.0', '13.0')
             or "ocabot-merge" in os.environ.get('TRAVIS_BRANCH', '')
         )
         and os.environ.get('TRAVIS_PULL_REQUEST') == 'false'
         and os.environ.get('GITHUB_USER')
-        and os.environ.get('GITHUB_EMAIL') 
+        and os.environ.get('GITHUB_EMAIL')
         and os.environ.get('GITHUB_TOKEN')
     )
     if must_run_makepot:

--- a/travis/travis_makepot
+++ b/travis/travis_makepot
@@ -35,9 +35,12 @@ def main(argv=None, database=None):
     travis_dependencies_dir = os.path.join(travis_home, 'dependencies')
     travis_build_dir = os.environ.get("TRAVIS_BUILD_DIR", "../..")
     server_path = get_server_path(odoo_full, odoo_version, travis_home)
-    addons_path = get_addons_path(travis_dependencies_dir,
-                                  travis_build_dir,
-                                  server_path)
+    addons_path = ""
+    # when installing with pip we don't need an addons_path
+    if os.environ.get("MQT_DEP", "OCA") == "OCA":
+        addons_path = get_addons_path(travis_dependencies_dir,
+                                      travis_build_dir,
+                                      server_path)
     addons_list = get_addons_to_check(travis_build_dir, odoo_include,
                                       odoo_exclude)
     addons = ','.join(addons_list)


### PR DESCRIPTION
We don't need an `addons_path` when addons are installed with pip,
and if we have the same addon in several places in the `addons_path`, this confuse
.pot file generation.

Follow-up from #646 