### PR TITLE
give package name cue to pip install

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -119,11 +119,13 @@ if [[ "${MQT_DEP}" == "OCA" ]] ; then
     clone_oca_dependencies
 else
     echo "Installing addons to test and their dependencies"
+    SHORT_VERSION=$(echo $VERSION | cut -d '.' -f 1)
     if [[ "${VERSION}" == "10.0" || "${VERSION}" == "9.0" || "${VERSION}" == "8.0" ]] ; then
         pip install odoo-autodiscover
     fi
     for addon in $(ls setup/ -I README -I _metapackage) ; do
-        echo "-e ./setup/${addon}" >> test-requirements.txt
+        addon_dist="odoo${SHORT_VERSION}-addon-${addon}"
+        echo "-e file://${PWD}/setup/${addon}#egg=${addon_dist}" >> test-requirements.txt
     done
     # use OCA wheelhouse because it is slightly fresher than PyPI
     pip install --pre -e ${ODOO_PATH} -r test-requirements.txt \


### PR DESCRIPTION
When providing a list of editable installs, it is important
to give pip a cue about the name of packages being installed
(#egg=) so it knows which one will be editable and it will
not attempt to fetch them from indexes as dependencies.

Side note: we want them editable so coverage picks-up the source code.