### PR TITLE
do not install odoo-autodiscover in MQT_DEP=PIP mode

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -120,9 +120,6 @@ if [[ "${MQT_DEP}" == "OCA" ]] ; then
 else
     echo "Installing addons to test and their dependencies"
     SHORT_VERSION=$(echo $VERSION | cut -d '.' -f 1)
-    if [[ "${VERSION}" == "10.0" || "${VERSION}" == "9.0" || "${VERSION}" == "8.0" ]] ; then
-        pip install odoo-autodiscover
-    fi
     for addon in $(ls setup/ -I README -I _metapackage) ; do
         addon_dist="odoo${SHORT_VERSION}-addon-${addon}"
         echo "-e file://${PWD}/setup/${addon}#egg=${addon_dist}" >> test-requirements.txt


### PR DESCRIPTION
It confuses runbot (or is it travis2docker?).

It is not needed in this specific case because odoo is installed
with -e too and comes first in sys.path so it's `__init__.py` is imported first.