### PR TITLE
remove unused transifex requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,6 @@ unittest2
 six
 configparser
 
-# transifex requirements
-polib
-slumber
-transifex-client==0.12.5
-
 # Supports code-block for module/README.rst
 # More info about: https://github.com/OCA/maintainer-quality-tools/issues/568
 pygments


### PR DESCRIPTION
Since these are unused yet installed in all builds, let's save some travis cycles.