### PR TITLE
remove dependency on configparser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ pyyaml==3.13 ; python_version >= '3.7'
 websocket-client
 unittest2
 six
-configparser
 
 # Supports code-block for module/README.rst
 # More info about: https://github.com/OCA/maintainer-quality-tools/issues/568

--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -10,7 +10,10 @@ from six import string_types
 from getaddons import (
     get_addons, get_modules, get_modules_info, get_dependencies)
 from travis_helpers import success_msg, fail_msg
-from configparser import ConfigParser
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 
 
 def has_test_errors(fname, dbname, odoo_version, check_loaded=True):
@@ -272,11 +275,12 @@ def create_server_conf(data, version):
         # If not exists the file then is created
         fconf = open(fname_conf, "w")
         fconf.close()
-    config = ConfigParser()
+    config = ConfigParser.ConfigParser()
     config.read(fname_conf)
     if not config.has_section('options'):
-        config['options'] = {}
-    config['options'].update(data)
+        config.add_section('options')
+    for key, value in data.items():
+        config.set('options', key, value)
     with open(fname_conf, 'w') as configfile:
         config.write(configfile)
 


### PR DESCRIPTION
use py2/py3 compatible code

`configparser` is the only dependency that was needed in addition to regular Odoo dependencies in order to run `test_server.py`. Removing it makes it possible to avoid MQT's `requirements.txt` in most cases.