### PR TITLE
[FIX] Add pylint_odoo dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 simplejson
+pylint_odoo
 pyserial
 pyopenssl>=16.2.0
 pyyaml==3.12 ; python_version < '3.7'


### PR DESCRIPTION
If you `pip install -r requirements.txt` and then try to run `git/pre-commit`, it will error because pylint is missing.