### PR TITLE
Install MQT dependencies in PIP mode too

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -117,6 +117,8 @@ if [[ "${MQT_DEP}" == "OCA" ]] ; then
     clone_oca_dependencies
 else
     pip install --upgrade pip setuptools wheel
+    # Needed for tour tests to not be skipped
+    pip install --upgrade websocket-client
 
     echo "Installing Odoo"
     pip install -r ${ODOO_PATH}/requirements.txt -e ${ODOO_PATH}


### PR DESCRIPTION
This should re-enable tours everywhere where PIP mode is being used and tours are being skipped.

See https://github.com/OCA/social/pull/560#issuecomment-651704674 and https://github.com/OCA/social/pull/555#issuecomment-651687647.

@sbidoul @Tecnativa TT24523