### PR TITLE
IMP: apply autoflake to remove unsed imports

### DIFF
--- a/sample_files/pre-commit-13.0/.pre-commit-config.yaml
+++ b/sample_files/pre-commit-13.0/.pre-commit-config.yaml
@@ -13,6 +13,11 @@ exclude: |
 default_language_version:
   python: python3
 repos:
+  - repo: https://github.com/myint/autoflake
+    rev: master
+    hooks:
+      - id: autoflake
+        args: [ "-i", "--remove-all-unused-imports", "--ignore-init-module-imports" ]
   - repo: https://github.com/psf/black
     rev: 19.10b0
     hooks:


### PR DESCRIPTION
Before, unsed import must be removed manually by developer, but with this hook this task can be automated

is possible propagate this hook to every repo on OCA???

![image](https://user-images.githubusercontent.com/7775116/94039032-d0e2e180-fd8c-11ea-90ad-da7a362652fe.png)

What do you think  @sbidoul @Yajo  @pedrobaeza 