### PR TITLE
[RFR] pre-commit: prevent pyupgrade to replace printf by str.format()

### DIFF
--- a/sample_files/pre-commit-13.0/.pre-commit-config.yaml
+++ b/sample_files/pre-commit-13.0/.pre-commit-config.yaml
@@ -90,6 +90,7 @@ repos:
     rev: v1.26.2
     hooks:
       - id: pyupgrade
+        args: [--keep-percent-format]
   - repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:


### PR DESCRIPTION
So as not to encourage developers to use str.format() as there are cases
where it can introduce security issues.

See https://github.com/OCA/pylint-odoo/issues/302