### PR TITLE
Use our own package index

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -136,9 +136,11 @@ else
     done
 fi
 
-# use OCA wheelhouse because it is slightly fresher than PyPI
+# Use a package index that redirects to the OCA wheelhouse for Odoo addons,
+# and to pypi.org for all other packages. This is to make sure we don't
+# inadvertently accepts non-OCA addons in dependencies.
 pip install --pre -r test-requirements.txt \
-    --extra-index-url https://wheelhouse.odoo-community.org/oca-simple/
+    --index-url https://wheelhouse.odoo-community.org/oca-simple-and-pypi/
 
 # Use reference .coveragerc
 cp ${HOME}/maintainer-quality-tools/cfg/.coveragerc .


### PR DESCRIPTION
Use a package index that redirects to the OCA wheelhouse for Odoo addons,
and to pypi.org for all other packages. This is to make sure we don't
inadvertently accept non-OCA addons in dependencies.

This index is made using [simpleindex](https://pypi.org/project/simpleindex/) with the following configuration:

```
# Serve Odoo addons from the OCA wheelhouse.
[routes."oca-simple-and-pypi/odoo{series}-addon-{addon}"]
source = "http"
to = "https://wheelhouse.odoo-community.org/oca-simple/odoo{series}-addon-{addon}/"

# Otherwise use PyPI.
[routes."oca-simple-and-pypi/{project}"]
source = "http"
to = "https://pypi.org/simple/{project}/"

[server]
host = ...
port = ...
```
