### PR TITLE
Upgrade setuptools

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -105,7 +105,7 @@ MQT_DEP=${MQT_DEP:-OCA}
 if [[ "${MQT_DEP}" == "OCA" ]] ; then
     # Workaround to force using system site packages (see https://github.com/Shippable/support/issues/241#issuecomment-57947925)
     rm -f $VIRTUAL_ENV/lib/python2.7/no-global-site-packages.txt
-    pip install --upgrade pip
+    pip install --upgrade pip setuptools
     pip install -q -r ${HOME}/maintainer-quality-tools/requirements.txt
 
     # Remove python-ldap from odoo requirements because is not a common module used


### PR DESCRIPTION
Using a fresh setuptools helps in some case, as it obey python-requires properly, and more and more packages have recent releases that require python >= 3 and must be avoided for python 2.