### PR TITLE
[FIX] avoid setuptools 58 that removed support for 2to3

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -105,7 +105,7 @@ MQT_DEP=${MQT_DEP:-OCA}
 if [[ "${MQT_DEP}" == "OCA" ]] ; then
     # Workaround to force using system site packages (see https://github.com/Shippable/support/issues/241#issuecomment-57947925)
     rm -f $VIRTUAL_ENV/lib/python2.7/no-global-site-packages.txt
-    pip install --upgrade pip setuptools
+    pip install --upgrade pip "setuptools<58"
     pip install -q -r ${HOME}/maintainer-quality-tools/requirements.txt
 
     # Remove python-ldap from odoo requirements because is not a common module used
@@ -119,7 +119,7 @@ if [[ "${MQT_DEP}" == "OCA" ]] ; then
     echo "Getting addons dependencies"
     clone_oca_dependencies
 else
-    pip install --upgrade pip setuptools wheel
+    pip install --upgrade pip "setuptools<58" wheel
     # Needed for tour tests to not be skipped
     pip install --upgrade websocket-client
 


### PR DESCRIPTION
- 2to3 support has been [removed since setuptools 58.0.0](https://setuptools.readthedocs.io/en/latest/history.html#breaking-changes)
- some deps of odoo use it, e.g. [feedparser==5.2.1](https://github.com/odoo/odoo/blob/14.0/requirements.txt#L6): [`setup.py`](https://github.com/kurtmckee/feedparser/blob/5.2.1/setup.py#L6)
- as a consequence, travis builds will fail:
```
Collecting feedparser==5.2.1

  Downloading feedparser-5.2.1.zip (1.2 MB)

    ERROR: Command errored out with exit status 1:

     command: /home/travis/virtualenv/python3.6.7/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-tj513bvt/feedparser_2b08e92758ea44ac9203ddee5abb9821/setup.py'"'"'; __file__='"'"'/tmp/pip-install-tj513bvt/feedparser_2b08e92758ea44ac9203ddee5abb9821/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-xk29crje

         cwd: /tmp/pip-install-tj513bvt/feedparser_2b08e92758ea44ac9203ddee5abb9821/

    Complete output (1 lines):

    error in feedparser setup command: use_2to3 is invalid.
    
(...)

ERROR: Could not find a version that satisfies the requirement feedparser==5.2.1 (from versions: 4.1, 5.0, 5.0.1, 5.1, 5.1.1, 5.1.2, 5.1.3, 5.2.0.post1, 5.2.1, 6.0.0b1, 6.0.0b2, 6.0.0b3, 6.0.0, 6.0.1, 6.0.2, 6.0.3, 6.0.4, 6.0.5, 6.0.6, 6.0.7, 6.0.8)
ERROR: No matching distribution found for feedparser==5.2.1

The command "travis_install_nightly" failed and exited with 1 during 
```
- so we need to pin `setuptools<58`, at least until said deps are bumped (which could take time)
- note that oca builds don't fail now, because wheels are available in the cache (ie pip install: `Using cached feedparser-5.2.1-py3-none-any.whl`); but sooner or later when cache will be obsolete or expired, they will fail