### PR TITLE
[FIX] runbot builds failing because of expired Let's Encrypt Root CA

### DIFF
--- a/travis/travis_install_nightly
+++ b/travis/travis_install_nightly
@@ -136,6 +136,16 @@ else
     done
 fi
 
+# runbot only
+if [ "x${CI}" == "x" ] ; then
+    # https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
+    # Remove expired root certificate so that the new chain could be properly validated on Trusty
+    sed -e '/Issuer: CN=DST Root CA X3/,+26d' /usr/local/lib/python2.7/dist-packages/certifi/cacert.pem > ${HOME}/cacert.pem
+
+    # Force requests (used by pip) to use the fixed system bundle
+    export REQUESTS_CA_BUNDLE=${HOME}/cacert.pem
+fi
+
 # Use a package index that redirects to the OCA wheelhouse for Odoo addons,
 # and to pypi.org for all other packages. This is to make sure we don't
 # inadvertently accepts non-OCA addons in dependencies.


### PR DESCRIPTION
Hi,

This is a quick attempt at fixing failed runbot builds such as [the one here](https://github.com/OCA/delivery-carrier/pull/423).

- [OCA's wheelhouse](https://wheelhouse.odoo-community.org) uses a Let's Encrypt cross-signed / old Android-compatible certificate (default)
- The old Root CA from Let's Encrypt has [expired](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/)
- Runbot docker containers rely on a [trusty (14.04) docker image](https://github.com/Vauxoo/docker-ubuntu-base/blob/master/Dockerfile#L1) (`vauxoo/odoo-80-image-shippable-auto:latest -> vauxoo/odoo-80-image -> vauxoo/docker-ubuntu-base:latest -> ubuntu:14.04`)
- When attempting to get packages from the Wheelhouse at the image creation, pip will fail because of the certificate:

```
[91mWARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:748)'),)': /oca-simple-and-pypi/odoo-test-helper/
```

- For the new valid chain to be taken into account, the expired Root CA must be removed first because of an [old openssl bug](https://community.letsencrypt.org/t/openssl-client-compatibility-changes-for-let-s-encrypt-certificates/143816)

Here is a reproduction of the issue and the fix:
```shell
$ docker run --user=odoo -it --rm vauxoo/odoo-80-image-shippable-auto bash
$ python -c "import requests; requests.get('https://valid-isrgrootx1.letsencrypt.org');" && echo "OK"
OK
$ python -c "import requests; requests.get('https://wheelhouse.odoo-community.org');" && echo "OK"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 75, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 655, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/adapters.py", line 514, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='wheelhouse.odoo-community.org', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLError(1, u'[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)'),))
$ sed -e '/Issuer: CN=DST Root CA X3/,+26d' /usr/local/lib/python2.7/dist-packages/certifi/cacert.pem > ${HOME}/cacert.pem
$ export REQUESTS_CA_BUNDLE=${HOME}/cacert.pem
$ python -c "import requests; requests.get('https://wheelhouse.odoo-community.org');" && echo "OK"
OK
```

I'm aware that this issue should ideally be fixed at the [`docker-ubuntu-base`](https://github.com/Vauxoo/docker-ubuntu-base) level, but doing so will require to fix a bunch of other unrelated issues (missing apt repos...)

Note that a **good alternative** to this fix would be to regenerate the Let's Encrypt certificate with `$ certbot renew --force-renewal --preferred-chain "ISRG Root X1"` which would make it compatible out of the box with Trusty as shown in the above command lines with the first case of `https://valid-isrgrootx1.letsencrypt.org`, but incompatible with Android < 7.1.1 devices (which I think is fine, as old android devices installing oca packages are quite rare :)).