### PR TITLE
[NEW] Setup database template / unaccent on travis and runbot

### DIFF
--- a/travis/test_server.py
+++ b/travis/test_server.py
@@ -210,7 +210,7 @@ def cmd_strip_secret(cmd):
 
 
 def setup_server(db, odoo_unittest, tested_addons, server_path, script_name,
-                 addons_path, install_options, preinstall_modules=None,
+                 addons_path, install_options, setup_dbtemplate, preinstall_modules=None,
                  unbuffer=True, server_options=None):
     """
     Setup the base module before running the tests
@@ -222,6 +222,7 @@ def setup_server(db, odoo_unittest, tested_addons, server_path, script_name,
     :param script_name: name of the main server file
     :param addons_path: Addons path
     :param install_options: Install options (travis parameter)
+    :param setup_dbtemplate: use an alternative database template
     :param preinstall_modules: (list) Modules that should be preinstalled
     :param unbuffer: keeps output colors
     :param server_options: (list) Add these flags to the Odoo server init
@@ -232,7 +233,7 @@ def setup_server(db, odoo_unittest, tested_addons, server_path, script_name,
         server_options = []
     print("\nCreating instance:")
     try:
-        subprocess.check_call(["createdb", db])
+        subprocess.check_call(["createdb", "-T", setup_dbtemplate, db])
     except subprocess.CalledProcessError:
         print("Using previous openerp_template database.")
     else:
@@ -315,6 +316,7 @@ def main(argv=None):
     data_dir = os.path.expanduser(os.environ.get("DATA_DIR", '~/data_dir'))
     test_enable = str2bool(os.environ.get('TEST_ENABLE', True))
     dbtemplate = os.environ.get('MQT_TEMPLATE_DB', 'openerp_template')
+    setup_dbtemplate = os.environ.get('SETUP_TEMPLATE_DB', 'template0')
     database = os.environ.get('MQT_TEST_DB', 'openerp_test')
     if not odoo_version:
         # For backward compatibility, take version from parameter
@@ -367,8 +369,8 @@ def main(argv=None):
         os.environ.get('TRAVIS_BUILD_DIR')))) or ['base']
     print("Modules to preinstall: %s" % preinstall_modules)
     setup_server(dbtemplate, odoo_unittest, tested_addons_list, server_path,
-                 script_name, addons_path, install_options, preinstall_modules,
-                 unbuffer, server_options)
+                 script_name, addons_path, install_options, setup_dbtemplate,
+                 preinstall_modules, unbuffer, server_options)
 
     # Running tests
     cmd_odoo_test = ["coverage", "run",

--- a/travis/travis_makepot
+++ b/travis/travis_makepot
@@ -39,6 +39,7 @@ def main(argv=None, database=None):
     travis_home = os.environ.get("HOME", "~/")
     travis_dependencies_dir = os.path.join(travis_home, 'dependencies')
     travis_build_dir = os.environ.get("TRAVIS_BUILD_DIR", "../..")
+    setup_dbtemplate = os.environ.get('SETUP_TEMPLATE_DB', 'template0')
     server_path = os.environ.get("PYTHONPATH")
     # when installing with pip we don't need 
     if os.environ.get("MQT_DEP", "OCA") == "OCA":
@@ -62,7 +63,8 @@ def main(argv=None, database=None):
         print("\nInitializing db %s to generate .pot for: %s" % (database, addons))
         script_name = get_server_script(server_path)
         setup_server(database, odoo_unittest, addons_list, server_path,
-                     script_name, addons_path, install_options, addons_list)
+                     script_name, addons_path, install_options, setup_dbtemplate,
+                     addons_list)
     else:
         print("\nUsing db %s to generate .pot" % (database, ))
 


### PR DESCRIPTION
Hi,

We are trying to run OCA travis tests with the unaccent extension:

https://github.com/OCA/l10n-brazil/pull/1701/files#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485

It was only possible when we added this new optional parameter that allows you to use a template database in the test setup.

