### PR TITLE
[FIX] pylint: Compatibility pylint<2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,9 @@ install:
   - cp -r ../maintainer-quality-tools/ $HOME
   - cp -r tests/test_repo/* ./
   - export PATH=$HOME/maintainer-quality-tools/travis:$PATH
+  # Fix AttributeError: 'str' object has no attribute 'name'
+  #   https://stackoverflow.com/a/59549323/3753497
+  - pip install -U --force-reinstall pluggy
    # Force install lint requirements in all cases of MQT for self_test script.
   - pip install coverage
   - LINT_CHECK="1" travis_install_nightly 8.0 # only used if VERSION not set in env

--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -168,8 +168,8 @@ def pylint_run(is_pr, version, dir):
 
     real_errors = main(cmd, standalone_mode=False)
     res = dict(
-        (key, value) for key, value in (real_errors.get(
-            'by_msg') or {}).items() if key not in beta_msgs)
+        (key, value) for key, value in (real_errors.by_msg
+            or {}).items() if key not in beta_msgs)
     count_errors = get_count_fails(real_errors, list(beta_msgs))
     count_info = "count_errors %s" % count_errors
     print(count_info)
@@ -189,8 +189,8 @@ def pylint_run(is_pr, version, dir):
         cmd = conf + modules_changed_cmd + extra_params_cmd
         pr_real_errors = main(cmd, standalone_mode=False)
         pr_stats = dict(
-            (key, value) for key, value in (pr_real_errors.get(
-                'by_msg') or {}).items() if key not in beta_msgs)
+            (key, value) for key, value in (pr_real_errors.by_msg
+                or {}).items() if key not in beta_msgs)
         if pr_stats:
             pr_errors = get_count_fails(pr_real_errors, list(beta_msgs))
             print(travis_helpers.yellow(
@@ -214,8 +214,8 @@ def get_count_fails(linter_stats, msgs_no_count=None):
     :return: Integer with quantity of fails found.
     """
     return sum([
-        linter_stats['by_msg'][msg]
-        for msg in (linter_stats.get('by_msg') or {})
+        linter_stats.by_msg[msg]
+        for msg in (linter_stats.by_msg or {})
         if msg not in msgs_no_count])
 
 
@@ -286,6 +286,11 @@ def run_pylint(paths, cfg, beta_msgs=None, sys_paths=None, extra_params=None):
         pylint_res = pylint.lint.Run(cmd, do_exit=False)
     else:
         pylint_res = pylint.lint.Run(cmd, exit=False)
+    if not hasattr(pylint_res.linter.stats, 'by_msg'):
+        # pylint<2.12 compatibility
+        class stats(object):
+            by_msg = pylint_res.linter.stats['by_msg']
+        setattr(pylint_res.linter, 'stats', stats)
     return pylint_res.linter.stats
 
 


### PR DESCRIPTION
Compatible with new way to get result of messages based on:
 - https://github.com/PyCQA/pylint/commit/16c09cb48a3c66f453faccdf380aea6969d61202#diff-3a681c16a79ae9818f939e08df8b9bb92ef9ce6d5fc65c360d7c9b526c3c3410R507