### PR TITLE
[REF] run_pylint: Compatibility with pylint>2.12

### DIFF
--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -168,8 +168,8 @@ def pylint_run(is_pr, version, dir):
 
     real_errors = main(cmd, standalone_mode=False)
     res = dict(
-        (key, value) for key, value in (real_errors.by_msg
-            or {}).items() if key not in beta_msgs)
+        (key, value) for key, value in (real_errors.get(
+            'by_msg') or {}).items() if key not in beta_msgs)
     count_errors = get_count_fails(real_errors, list(beta_msgs))
     count_info = "count_errors %s" % count_errors
     print(count_info)
@@ -189,8 +189,8 @@ def pylint_run(is_pr, version, dir):
         cmd = conf + modules_changed_cmd + extra_params_cmd
         pr_real_errors = main(cmd, standalone_mode=False)
         pr_stats = dict(
-            (key, value) for key, value in (pr_real_errors.by_msg
-                or {}).items() if key not in beta_msgs)
+            (key, value) for key, value in (pr_real_errors.get(
+                'by_msg') or {}).items() if key not in beta_msgs)
         if pr_stats:
             pr_errors = get_count_fails(pr_real_errors, list(beta_msgs))
             print(travis_helpers.yellow(
@@ -214,8 +214,8 @@ def get_count_fails(linter_stats, msgs_no_count=None):
     :return: Integer with quantity of fails found.
     """
     return sum([
-        linter_stats.by_msg[msg]
-        for msg in (linter_stats.by_msg or {})
+        linter_stats['by_msg'][msg]
+        for msg in (linter_stats.get('by_msg') or {})
         if msg not in msgs_no_count])
 
 
@@ -286,11 +286,6 @@ def run_pylint(paths, cfg, beta_msgs=None, sys_paths=None, extra_params=None):
         pylint_res = pylint.lint.Run(cmd, do_exit=False)
     else:
         pylint_res = pylint.lint.Run(cmd, exit=False)
-    if not hasattr(pylint_res.linter.stats, 'by_msg'):
-        # pylint<2.12 compatibility
-        class stats(object):
-            by_msg = pylint_res.linter.stats['by_msg']
-        setattr(pylint_res.linter, 'stats', stats)
     return pylint_res.linter.stats
 
 

--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -286,6 +286,9 @@ def run_pylint(paths, cfg, beta_msgs=None, sys_paths=None, extra_params=None):
         pylint_res = pylint.lint.Run(cmd, do_exit=False)
     else:
         pylint_res = pylint.lint.Run(cmd, exit=False)
+    if hasattr(pylint_res.linter.stats, 'by_msg'):
+        # pylint>2.12 compatibility
+        pylint_res.linter.stats = {'by_msg': pylint_res.linter.stats.by_msg}
     return pylint_res.linter.stats
 
 


### PR DESCRIPTION
The following commit:
 - https://github.com/OCA/maintainer-quality-tools/commit/365183598bc86889de0349aa23d015cc5f356577

It is compatible with new way to get result of messages based on:
 - https://github.com/PyCQA/pylint/commit/16c09cb#diff-3a681c16a79ae9818f939e08df8b9bb92ef9ce6d5fc65c360d7c9b526c3c3410R507

However, new corner cases were raised

e.g. https://github.com/OCA/sale-workflow/pull/2004#issuecomment-1118506829

It is because the test_pylint script consider returns early using a dict

So, we need to transform new way object to old way dict in order to be compatible with this old script
with minimal changes since that new pylint checks are available from pre-commit
