### PR TITLE
Using python3 keyword-only arguments or annotated arguments causes a ValueError

### DIFF
--- a/travis/run_pylint.py
+++ b/travis/run_pylint.py
@@ -281,7 +281,7 @@ def run_pylint(paths, cfg, beta_msgs=None, sys_paths=None, extra_params=None):
     if not subpaths:
         return {'error': 0}
     cmd.extend(subpaths)
-    if 'do_exit' in inspect.getargspec(pylint.lint.Run.__init__)[0]:
+    if 'do_exit' in inspect.getfullargspec(pylint.lint.Run.__init__)[0]:
         # pylint has renamed this keyword argument
         pylint_res = pylint.lint.Run(cmd, do_exit=False)
     else:


### PR DESCRIPTION
When running travis in a task, the error 
`ValueError: Function has keyword-only parameters or annotations, use getfullargspec() API which can support them`

shows up