### PR TITLE
Update pyyaml otherwise pip install will fail

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ simplejson
 pyserial
 pyopenssl>=16.2.0
 pyyaml==3.12 ; python_version < '3.7'
-pyyaml==5.4 ; python_version >= '3.7'
+pyyaml==6.0 ; python_version >= '3.7'
 websocket-client
 unittest2
 six


### PR DESCRIPTION
With the current version of pyyaml the script **travis_install_nightly** will fail at line https://github.com/OCA/maintainer-quality-tools/blob/7d99e8d90a9f493c697cbb86d2d8176814fc0f56/travis/travis_install_nightly#L109C5-L109C6 with the following error:

`  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [62 lines of output]
      /tmp/pip-build-env-esorkkhj/overlay/lib/python3.10/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
      !!
      
              ********************************************************************************
              The license_file parameter is deprecated, use license_files instead.
      
              By 2023-Oct-30, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.
      
              See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
              ********************************************************************************
      
      !!`

By updating pyyaml to 6.0 the problem is resolved.